### PR TITLE
re-org how we formulate our response + tasks

### DIFF
--- a/lambda/src/server/deferred_tasks.clj
+++ b/lambda/src/server/deferred_tasks.clj
@@ -1,0 +1,5 @@
+(ns server.deferred-tasks)
+
+(defmacro register-var! [sym]
+  {:pre [(and (list? sym) (= 'quote (first sym)))]}
+  `(~'server.deferred-tasks/alias* ~sym ~(second sym)))

--- a/lambda/src/server/main.cljs
+++ b/lambda/src/server/main.cljs
@@ -28,25 +28,23 @@
   "Main AWS Lambda handler. Invoked by slackBot.
    See https://docs.aws.amazon.com/lambda/latest/dg/nodejs-handler.html"
   [^:js {:as req :keys [body]} ^js res]
-  (let [{:as result
-         :keys [response
-                task]} (cond
-                         ;; Slack API: identification challenge
-                         (:challenge body) {:response (:challenge body)}
+  (p/let [{:as result
+           :keys [response
+                  task]} (cond
+                           ;; Slack API: identification challenge
+                           (:challenge body) {:response (:challenge body)}
 
-                         ;; Slack Interaction (e.g. global shortcut)
-                         (:payload body) (handlers/handle-interaction! (:payload body))
+                           ;; Slack Interaction (e.g. global shortcut)
+                           (:payload body) (handlers/handle-interaction! (:payload body))
 
-                         ;; Slack Event
-                         (:event body) (handlers/handle-event! (:event body)))]
+                           ;; Slack Event
+                           (:event body) (handlers/handle-event! (:event body)))]
+
     (assert (or (map? result) (nil? result)))
+    (pp/pprint [(if result ::handled ::not-handled) body])
+    (when task (tasks/publish! task))
 
-    (pp/pprint (if result
-                 [::handled body]
-                 [::not-handled body]))
-    (p/do
-      (when task (tasks/publish! task))
-      (.send res response))))
+    (.send res response)))
 
 (def app
   (doto ^js (express)

--- a/lambda/src/server/main.cljs
+++ b/lambda/src/server/main.cljs
@@ -28,23 +28,25 @@
   "Main AWS Lambda handler. Invoked by slackBot.
    See https://docs.aws.amazon.com/lambda/latest/dg/nodejs-handler.html"
   [^:js {:as req :keys [body]} ^js res]
-  (pp/pprint ["[handler] body:" body])
+  (let [{:as result
+         :keys [response
+                task]} (cond
+                         ;; Slack API: identification challenge
+                         (:challenge body) {:response (:challenge body)}
 
-  (p/try (p/let [response (cond
-                            ;; Slack API: identification challenge
-                            (:challenge body) (:challenge body)
+                         ;; Slack Interaction (e.g. global shortcut)
+                         (:payload body) (handlers/handle-interaction! (:payload body))
 
-                            ;; Slack Interaction (e.g. global shortcut)
-                            (:payload body) (handlers/handle-interaction! (:payload body))
+                         ;; Slack Event
+                         (:event body) (handlers/handle-event! (:event body)))]
+    (assert (or (map? result) (nil? result)))
 
-                            ;; Slack Event
-                            (:event body)
-                            (handlers/handle-event! (:event body)))]
-
-           (.send res (when (string? response) response)))
-         (p/catch js/Error e
-           (pp/pprint [:error e])
-           (-> res (.status 500) (.send "Server error")))))
+    (pp/pprint (if result
+                 [::handled body]
+                 [::not-handled body]))
+    (p/do
+      (when task (tasks/publish! task))
+      (.send res response))))
 
 (def app
   (doto ^js (express)

--- a/lambda/src/server/slack.cljs
+++ b/lambda/src/server/slack.cljs
@@ -44,7 +44,7 @@
                             :headers {:Authorization (str "Bearer " bot-token)}
                             :body (clj->js body) #_(.stringify js/JSON (clj->js body))})))
 
-(tasks/alias! ::post post+)
+(tasks/register-var! `post+)
 
 (defn post-query-string+ [family-method query-params]
   ;; This fn is a hack to work around broken JSON bodies in Slack's API
@@ -53,7 +53,7 @@
                             :Content-Type "application/json; charset=utf-8"
                             :headers {:Authorization (str "Bearer " bot-token)}})))
 
-(tasks/alias! ::post-query-string post-query-string+)
+(tasks/register-var! `post-query-string+)
 
 (comment
   (p/-> (get+ "users.list")
@@ -70,7 +70,7 @@
          ;; TODO better callback
          (println "slack views.open response:")))
 
-(tasks/alias! ::views-open views-open!)
+(tasks/register-var! `views-open!)
 
 (defn views-update! [view-id blocks]
   (p/->> (post-query-string+ "views.update"
@@ -79,4 +79,4 @@
          ;; TODO better callback
          (println "slack views.update response:")))
 
-(tasks/alias! ::views-update views-update!)
+(tasks/register-var! `views-update!)

--- a/lambda/src/server/slack/handlers.cljs
+++ b/lambda/src/server/slack/handlers.cljs
@@ -34,14 +34,14 @@
            (p/all)
            (map http/assert-ok))))
 
-(tasks/alias! ::request-updates request-updates!)
+(tasks/register-var! `request-updates!)
 
 (defn handle-event! [{:as event
                       event-type :type
                       :keys [user channel tab]}]
   (case event-type
     "app_home_opened"
-    {:task [::slack/post-query-string "views.publish"
+    {:task [`slack/post-query-string+ "views.publish"
             {:user_id user
              :view
              (blocks/to-json
@@ -63,15 +63,15 @@
   (case payload-type
 
     ; Slack "Global shortcut"
-    "shortcut" {:task [::slack/views-open trigger_id screens/shortcut-modal]}
+    "shortcut" {:task [`slack/views-open! trigger_id screens/shortcut-modal]}
 
     ; User acted on existing view
     "block_actions"
     (case action_id
       "admin:team-broadcast"
       (case view-type
-        "modal" {:task [::slack/views-update view_id screens/team-broadcast-modal-compose]}
-        "home" {:task [::slack/views-open trigger_id screens/team-broadcast-modal-compose]})
+        "modal" {:task [`slack/views-update! view_id screens/team-broadcast-modal-compose]}
+        "home" {:task [`slack/views-open! trigger_id screens/team-broadcast-modal-compose]})
 
       ;; TODO FIXME
       #_"broadcast2:channel-select"
@@ -84,7 +84,7 @@
     ; "Submit" button pressed
     "view_submission"
     ;; In the future we will need to branch on other data
-    {:task [::request-updates (decode-text-input (get-in payload [:view
+    {:task [`request-updates! (decode-text-input (get-in payload [:view
                                                                   :state
                                                                   :values
                                                                   :sb-input1


### PR DESCRIPTION
Two main changes - 

- Use fully qualified var symbols to reference tasks instead of assigning a keyword to each task
- Have the main slack handler synchronously return a result map, which can contain `:response` and/or `task`

ideas being
- don't invent new names for referencing functions across lambda boundaries
- make the tasks-to-be-queued by the main handler visible at the top level

(not _entirely_ sure that returning `:task` is better than calling `tasks/publish!` deep inside a fn somewhere, but it felt a bit dirty to be adding the `tasks/publish!` side-effect in so many deep places... this should be easier to inspect/log/test?)