### PR TITLE
store bot tokens per-app, allow reinstall

### DIFF
--- a/lambda/src/server/blocks.cljs
+++ b/lambda/src/server/blocks.cljs
@@ -28,7 +28,8 @@
               :update-props {:text (partial wrap-string :md)}}
    "home" {:children :blocks}
    "modal" {:children :blocks
-            :update-props {:title (partial wrap-string :plain_text)}}})
+            :update-props {:title (partial wrap-string :plain_text)}}
+   "actions" {:children :elements}})
 
 (defn apply-schema [tag props body]
   (let [tag-type (type-string tag)

--- a/lambda/src/server/common.cljs
+++ b/lambda/src/server/common.cljs
@@ -2,7 +2,8 @@
   (:require [applied-science.js-interop :as j]
             [cljs.reader]
             [cognitect.transit :as transit]
-            [shadow.resource :as rc]))
+            [shadow.resource :as rc]
+            [clojure.string :as str]))
 
 (defn env-var [k]
   (j/get-in js/process [:env (name k)]))
@@ -52,3 +53,6 @@
 
 (def firebase-database-secret (:firebase/database-secret config))
 
+(j/defn lambda-root-url [^:js {:keys [headers url query]}]
+  (let [host (j/get headers :host)]
+    (str "https://" host (str/replace url #"(/slack.*)|/$" ""))))

--- a/lambda/src/server/firebase.cljs
+++ b/lambda/src/server/firebase.cljs
@@ -19,19 +19,17 @@
                  uri/map->query-string))
     (->> (prn :json-url))))
 
-(defn get+ [path & [opts]]
-  (http/fetch-json+ (json-url path opts)
-                    {:method "GET"}))
+(defn req-fn [method]
+  (fn [path & [{:as opts :keys [body]}]]
+    (http/fetch-json+ (json-url path opts)
+                      (-> {:method method}
+                          (cond-> body (assoc :body (common/clj->json body)))
+                          (clj->js)))))
 
-(defn put+ [path & [opts]]
-  (http/fetch-json+ (json-url path opts)
-                    (clj->js {:method "PUT"
-                              :body (some-> (:body opts) common/clj->json)})))
-
-(defn post+ [path & [opts]]
-  (http/fetch-json+ (doto (json-url path opts) prn)
-                    {:method "POST"
-                     :body (some-> (:body opts) common/clj->json)}))
+(def get+ (req-fn "GET"))
+(def put+ (req-fn "PUT"))
+(def post+ (req-fn "POST"))
+(def patch+ (req-fn "PATCH"))
 
 (defn map->list [id-key m]
   (reduce-kv (fn [out key value] (conj out (assoc value id-key (name key)))) [] m))

--- a/lambda/src/server/main.cljs
+++ b/lambda/src/server/main.cljs
@@ -30,12 +30,16 @@
   "Main AWS Lambda handler. Invoked by slackBot.
    See https://docs.aws.amazon.com/lambda/latest/dg/nodejs-handler.html"
   [^:js {:as req :keys [body]} ^js res]
-  (p/let [[kind data props] (cond (:payload body) [:interaction (:payload body) #:slack{:team-id (-> body :payload :team :id)
-                                                                                        :user-id (-> body :payload :user :id)
-                                                                                        :app-id (-> body :payload :api_app_id)}]
-                                  (:event body) [:event (:event body) #:slack{:team-id (:team_id body)
-                                                                              :user-id (-> body :event :user)
-                                                                              :app-id (:api_app_id body)}]
+  (p/let [[kind data props] (cond (:payload body) [:interaction
+                                                   (:payload body)
+                                                   #:slack{:team-id (-> body :payload :team :id)
+                                                           :user-id (-> body :payload :user :id)
+                                                           :app-id (-> body :payload :api_app_id)}]
+                                  (:event body) [:event
+                                                 (:event body)
+                                                 #:slack{:team-id (:team_id body)
+                                                         :user-id (-> body :event :user)
+                                                         :app-id (:api_app_id body)}]
                                   (:challenge body) [:challenge (:challenge body) nil])
           token (when (:slack/team-id props)
                   (slack-db/team->token props))

--- a/lambda/src/server/main.cljs
+++ b/lambda/src/server/main.cljs
@@ -30,10 +30,17 @@
   "Main AWS Lambda handler. Invoked by slackBot.
    See https://docs.aws.amazon.com/lambda/latest/dg/nodejs-handler.html"
   [^:js {:as req :keys [body]} ^js res]
-  (p/let [[kind data team-id] (cond (:payload body) [:interaction (:payload body) (-> body :payload :team :id)]
-                                    (:event body) [:event (:event body) (:team_id body)]
-                                    (:challenge body) [:challenge (:challenge body) nil])
-          token (some-> team-id slack-db/team->token)
+  (p/let [[kind data props] (cond (:payload body) [:interaction (:payload body) #:slack{:team-id (-> body :payload :team :id)
+                                                                                        :user-id (-> body :payload :user :id)
+                                                                                        :app-id (-> body :payload :api_app_id)}]
+                                  (:event body) [:event (:event body) #:slack{:team-id (:team_id body)
+                                                                              :user-id (-> body :event :user)
+                                                                              :app-id (:api_app_id body)}]
+                                  (:challenge body) [:challenge (:challenge body) nil])
+          token (when (:slack/team-id props)
+                  (slack-db/team->token props))
+          props (merge props {:lambda/req req
+                              :slack/token token})
           {:as result
            :keys [response
                   task]} (case kind
@@ -41,17 +48,16 @@
                            :challenge {:response data}
 
                            ;; Slack Interaction (e.g. global shortcut)
-                           :interaction (handlers/handle-interaction! token data)
+                           :interaction (handlers/handle-interaction! props data)
 
                            ;; Slack Event
-                           :event (handlers/handle-event! token data))]
+                           :event (handlers/handle-event! props data))]
 
     (assert (or (map? result) (nil? result)))
-    (pp/pprint [(if result ::handled ::not-handled) body])
+    ;(pp/pprint [(if result ::handled ::not-handled) body])
     (when task
       (pp/pprint task)
       (tasks/publish! task))
-
     (.send res response)))
 
 (def app
@@ -64,7 +70,7 @@
             (j/update! req :query js->clj :keywordize-keys true)
             (next)))
 
-    (.get "/slack/install" slack/install-redirect)
+    (.get "/slack/install" slack/oauth-install-redirect)
     (.get "/slack/oauth-redirect" slack/oauth-redirect)
 
     (.post "*" (fn [req res next] (#'handler* req res next)))))

--- a/lambda/src/server/slack.cljs
+++ b/lambda/src/server/slack.cljs
@@ -108,17 +108,23 @@
 
    This is how we verify who the user is, and what board to connect the
    app to (a board for which the user must be an admin)"
-  [^:js {:as req :keys [query]} res next]
-  (let [{:keys [team-id]} (tokens/firebase-decode (:state query))]
-    (.redirect res
-               (str "https://slack.com/oauth/v2/authorize?"
-                    (uri/map->query-string
-                      {:scope (str/join "," scopes)
-                       :team team-id
-                       :client_id (:client-id slack-config)
-                       :redirect_uri (str (common/lambda-root-url req) "/slack/oauth-redirect")
-                       ;; the `state` query parameter - a signed token from Sparkboard
-                       :state (:state query)})))))
+  [^:js {:as req :keys [query]} ^js res next]
+  (p/let [{:keys [team-id board-id]} (tokens/firebase-decode (:state query))
+          error (when board-id
+                  (p/let [entry (slack-db/board->team board-id)]
+                    (when (and entry (not= board-id (:board-id entry)))
+                      (str "This board is already linked to the Slack team " (:team-name entry)))))]
+    (if error
+      (-> res (.status 400) (.send error))
+      (.redirect res
+                 (str "https://slack.com/oauth/v2/authorize?"
+                      (uri/map->query-string
+                        {:scope (str/join "," scopes)
+                         :team team-id
+                         :client_id (:client-id slack-config)
+                         :redirect_uri (str (common/lambda-root-url req) "/slack/oauth-redirect")
+                         ;; the `state` query parameter - a signed token from Sparkboard
+                         :state (:state query)}))))))
 
 (j/defn oauth-redirect [^:js {:as req :keys [body query]} res next]
   (let [{:keys [code state]} query
@@ -139,28 +145,30 @@
                                                   :token access_token})]
           (assert (j/get-in user-response [:user :is_admin])
                   "Only an admin can install the Sparkboard app")
-          (p/all
-            [(slack-db/install-app!
-               {:slack/team-id team-id
-                :slack/team-name team-name
-                :slack/app-id app_id
-                :slack/bot-token access_token
-                :slack/bot-user-id bot_user_id})
-             (when board-id
-               (slack-db/link-team-to-board!
+          (p/try
+            (when board-id
+              (slack-db/link-team-to-board!
+                {:slack/team-id team-id
+                 :sparkboard/board-id board-id}))
+            (p/all
+              [(slack-db/install-app!
                  {:slack/team-id team-id
-                  :sparkboard/board-id board-id}))
-             (when account-id
-               (slack-db/link-user-to-account!
-                 {:slack/team-id team-id
-                  :slack/user-id user-id
-                  :sparkboard/account-id account-id}))])
-
-          (.redirect res (str "slack://open?"
-                              (uri/map->query-string
-                                {:team team-id
-                                 :id app_id
-                                 :tab "home"}))))))))
+                  :slack/team-name team-name
+                  :slack/app-id app_id
+                  :slack/bot-token access_token
+                  :slack/bot-user-id bot_user_id})
+               (when account-id
+                 (slack-db/link-user-to-account!
+                   {:slack/team-id team-id
+                    :slack/user-id user-id
+                    :sparkboard/account-id account-id}))])
+            (.redirect res (str "slack://open?"
+                                (uri/map->query-string
+                                  {:team team-id
+                                   :id app_id
+                                   :tab "home"})))
+            (p/catch js/Error ^js e
+              (.send res 400 (.-message e)))))))))
 
 (defn only-install-link [team-id lambda-root]
   ;; link that will let a user install app without linking to a board

--- a/lambda/src/server/slack.cljs
+++ b/lambda/src/server/slack.cljs
@@ -134,21 +134,21 @@
                            access_token]
                     {team-id :id team-name :name} :team
                     {user-id :id} :authed_user} response]
-        (prn :app-id app_id :response response)
         (p/let [user-response (get+ "users.info" {:query {:user user-id}
                                                   :token access_token})]
           (assert (j/get-in user-response [:user :is_admin])
                   "Only an admin can install the Sparkboard app")
-
           (p/all
-            [(slack-db/link-team-to-board!
+            [(slack-db/install-app!
                {:slack/team-id team-id
+                :slack/team-name team-name
                 :slack/app-id app_id
                 :slack/bot-token access_token
-                :slack/bot-user-id bot_user_id
-                :slack/team-name team-name
-                :sparkboard/board-id board-id})
-
+                :slack/bot-user-id bot_user_id})
+             (when board-id
+               (slack-db/link-team-to-board!
+                 {:slack/team-id team-id
+                  :sparkboard/board-id board-id}))
              (when account-id
                (slack-db/link-user-to-account!
                  {:slack/team-id team-id

--- a/lambda/src/server/slack/handlers.cljs
+++ b/lambda/src/server/slack/handlers.cljs
@@ -38,9 +38,10 @@
 
 (tasks/register-var! `request-updates!)
 
-(defn handle-event! [token {:as event
-                            event-type :type
-                            :keys [user channel tab]}]
+(defn handle-event! [{:as props
+                      :keys [slack/token]} {:as event
+                                            event-type :type
+                                            :keys [user channel tab]}]
   (case event-type
     "app_home_opened"
     {:task [`slack/post+ "views.publish"
@@ -48,7 +49,7 @@
              :query {:user_id user
                      :view
                      (blocks/to-json
-                       (screens/home))}}]}
+                       (screens/home props))}}]}
     nil))
 
 (defn decode-text-input [s]
@@ -57,16 +58,17 @@
   ;; input, specifically replacing spaces with `+`
   (str/replace s "+" " "))
 
-(defn handle-interaction! [token {payload-type :type
-                                  :keys [trigger_id]
-                                  [{:keys [action_id]}] :actions
-                                  {view-type :type} :view
-                                  {:as container :keys [view_id]} :container
-                                  :as payload}]
+(defn handle-interaction! [{:as props
+                            :keys [slack/token]} {payload-type :type
+                                                  :keys [trigger_id]
+                                                  [{:keys [action_id]}] :actions
+                                                  {view-type :type} :view
+                                                  {:as container :keys [view_id]} :container
+                                                  :as payload}]
   (case payload-type
 
     ; Slack "Global shortcut"
-    "shortcut" {:task [`slack/views-open! token trigger_id screens/shortcut-modal]}
+    "shortcut" {:task [`slack/views-open! token trigger_id (screens/shortcut-modal props)]}
 
     ; User acted on existing view
     "block_actions"

--- a/lambda/src/server/slack/screens.cljs
+++ b/lambda/src/server/slack/screens.cljs
@@ -4,7 +4,7 @@
             [server.common :as common]
             [server.slack :as slack]))
 
-(defn main-menu [{:as props :keys [lambda/req]}]
+(defn main-menu [{:as props :keys [lambda/req slack/team-id]}]
   (list
     [:section
      {:accessory [:button {:style "primary",
@@ -16,6 +16,7 @@
     [:section "Admin actions"]
     [:actions
      [:button {:url (slack/only-install-link
+                      team-id
                       (common/lambda-root-url req))} "Reinstall App"]]))
 
 (defn home [props]

--- a/lambda/src/server/slack/screens.cljs
+++ b/lambda/src/server/slack/screens.cljs
@@ -1,28 +1,35 @@
 (ns server.slack.screens
   (:require [applied-science.js-interop :as j]
-            [server.blocks :as blocks]))
+            [server.blocks :as blocks]
+            [server.common :as common]
+            [server.slack :as slack]))
 
-(def main-menu
-  [:section
-   {:accessory [:button {:style "primary",
-                         :action_id "admin:team-broadcast"
-                         :value "click_me_123"}
-                "Compose"]}
-   "*Team Broadcast*\nSend a message to all teams."])
+(defn main-menu [{:as props :keys [lambda/req]}]
+  (list
+    [:section
+     {:accessory [:button {:style "primary",
+                           :action_id "admin:team-broadcast"
+                           :value "click_me_123"}
+                  "Compose"]}
+     "*Team Broadcast*\nSend a message to all teams."]
+    [:divider]
+    [:section "Admin actions"]
+    [:actions
+     [:button {:url (slack/only-install-link
+                      (common/lambda-root-url req))} "Reinstall App"]]))
 
-(defn home []
+(defn home [props]
   [:home
-   main-menu
-   [:divider]
+   (main-menu props)
    [:section
     (str "_Last updated:_ "
          (-> (js/Date.)
              (.toLocaleString "en-US" #js{:dateStyle "medium"
                                           :timeStyle "medium"})))]])
 
-(def shortcut-modal
+(defn shortcut-modal [props]
   [:modal {:title "Broadcast"
-           :blocks [main-menu]}])
+           :blocks (main-menu props)}])
 
 (def team-broadcast-blocks
   (list
@@ -50,14 +57,14 @@
 
 (defn team-broadcast-message [msg]
   (list
-   [:section {:text {:type "mrkdwn" :text msg}}]
-   {:type "actions",
-    :elements [[:button {:style "primary"
-                         :text {:type "plain_text",
-                                :text "Post an Update",
-                                :emoji true},
-                         :action_id "user:team-broadcast-response"
-                         :value "click_me_123"}]]}))
+    [:section {:text {:type "mrkdwn" :text msg}}]
+    {:type "actions",
+     :elements [[:button {:style "primary"
+                          :text {:type "plain_text",
+                                 :text "Post an Update",
+                                 :emoji true},
+                          :action_id "user:team-broadcast-response"
+                          :value "click_me_123"}]]}))
 
 
 (comment

--- a/lambda/src/server/slack_db_linking.cljs
+++ b/lambda/src/server/slack_db_linking.cljs
@@ -35,8 +35,11 @@
 (defn link-team-to-board! [{:as entry
                             :keys [slack/team-id
                                    sparkboard/board-id]}]
-  (fire/put+ (str "/slack-team/" team-id "/board-id/")
-             {:body board-id}))
+  (p/let [path (str "/slack-team/" team-id "/board-id/")
+          existing-board (fire/get+ path)]
+    (cond (nil? existing-board) (fire/put+ path {:body board-id})
+          (= existing-board board-id) nil
+          :else (throw (js/Error. "This Slack team is already linked to a board.")))))
 
 (defn link-channel-to-project!
   [{:keys [slack/team-id

--- a/lambda/src/server/slack_db_linking.cljs
+++ b/lambda/src/server/slack_db_linking.cljs
@@ -103,7 +103,7 @@
   (p/->> (fire/get+ "/slack-team"
                     {:query
                      {:orderBy "board-id"
-                      :startAt board-id
+                      :equalTo board-id
                       :limitToFirst 1}})
          (fire/obj->list :team-id)
          first))

--- a/lambda/src/server/slack_db_linking.cljs
+++ b/lambda/src/server/slack_db_linking.cljs
@@ -24,9 +24,14 @@
 (defn link-team-to-board! [{:as entry
                             :keys [slack/team-id
                                    sparkboard/board-id
-                                   slack/bot-token]}]
-  (fire/put+ (str "/slack-team/" team-id)
-             {:body entry}))
+                                   slack/bot-token
+                                   slack/bot-user-id
+                                   slack/app-id]}]
+  (fire/patch+ (str "/slack-team/" team-id)
+               {:body (merge {(str "app/" app-id) {:bot-token bot-token
+                                                   :bot-user-id bot-user-id}}
+                             (when board-id
+                               {:board-id board-id}))}))
 
 (defn link-channel-to-project!
   [{:keys [slack/team-id
@@ -58,11 +63,9 @@
 (defn linked-team [team-id]
   (fire/get+ (str "/slack-team/" team-id)))
 
-(defn team->token [team-id]
-
-  (p/let [entry (fire/get+ (str "/slack-team/" team-id "/bot-token"))]
-    (prn :ti team-id entry)
-    entry))
+(defn team->token [{:slack/keys [app-id team-id]}]
+  {:pre [(and app-id team-id)]}
+  (fire/get+ (str "/slack-team/" team-id "/app/" app-id "/bot-token")))
 
 ;; lookups by index
 

--- a/lambda/src/server/slack_db_linking.cljs
+++ b/lambda/src/server/slack_db_linking.cljs
@@ -21,17 +21,22 @@
 
 ;; Create link entries
 
+(defn install-app! [{:as entry
+                     :keys [slack/team-id
+                            slack/team-name
+                            slack/bot-token
+                            slack/bot-user-id
+                            slack/app-id]}]
+  (fire/patch+ (str "/slack-team/" team-id)
+               {:body {(str "/app/" app-id) {:bot-token bot-token
+                                             :bot-user-id bot-user-id}
+                       :team-name team-name}}))
+
 (defn link-team-to-board! [{:as entry
                             :keys [slack/team-id
-                                   sparkboard/board-id
-                                   slack/bot-token
-                                   slack/bot-user-id
-                                   slack/app-id]}]
-  (fire/patch+ (str "/slack-team/" team-id)
-               {:body (merge {(str "app/" app-id) {:bot-token bot-token
-                                                   :bot-user-id bot-user-id}}
-                             (when board-id
-                               {:board-id board-id}))}))
+                                   sparkboard/board-id]}]
+  (fire/put+ (str "/slack-team/" team-id "/board-id/")
+             {:body board-id}))
 
 (defn link-channel-to-project!
   [{:keys [slack/team-id
@@ -134,8 +139,7 @@
   ;; create mock linkages
   (then-print
     (link-team-to-board! {:slack/team-id "team-1"
-                          :sparkboard/board-id "board-1"
-                          :slack/token "<TOKEN>"})
+                          :sparkboard/board-id "board-1"})
     (link-channel-to-project!
       {:slack/team-id "team-1"
        :slack/channel-id "channel-1"
@@ -158,4 +162,9 @@
 
     (account->all-linked-users "account-1")
     (team->all-linked-channels "team-1"))
+
+  (then-print
+    (link-team-to-board!
+      {:slack/team-id "T014098L9FD"
+       :sparkboard/board-id "demo"}))
   )


### PR DESCRIPTION
For dev purposes we need to be able to store tokens for more than one app, and generate install links locally.

With this PR, you can run the [only-install-link](https://github.com/sparkboard/sparkboard/pull/24/files#diff-b02fb39bf36c5ff858143b76d8f26b91R170) function with your ngrok url to get a link that will kick off the oauth-flow, install the app, and store the app's bot token in the db.