### PR TITLE
Refactor routing

### DIFF
--- a/src/org/sparkboard/server/handle.clj
+++ b/src/org/sparkboard/server/handle.clj
@@ -6,7 +6,7 @@
             [org.sparkboard.server.slack.screens :as screens]
             [org.sparkboard.slack.slack-db :as slack-db]
             [org.sparkboard.js-convert :refer [json->clj]]
-            [server.common :as common]
+            [server.common :as common] ;; TODO move ns to sensible dir
             [ring.util.http-response :as http]
             [taoensso.timbre :as log]))
 
@@ -19,18 +19,16 @@
   ;; input, specifically replacing spaces with `+`
   (string/replace s "+" " "))
 
-(defn request-updates [{:keys [slack/token]} msg reply-channel]
+(defn request-updates [props msg reply-channel]
   ;; TODO Write broadcast to Firebase
-  (log/info "[request-updates] msg:" msg)
+  (log/debug "[request-updates] msg:" msg)
   (let [blocks (hiccup/->blocks-json (screens/team-broadcast-message msg reply-channel))]
-    (mapv #(slack/web-api "chat.postMessage"
-                          {:channel %
-                           :blocks blocks
-                           :slack/token token})
+    (mapv #(slack/web-api "chat.postMessage" (:slack/token props)
+                          {:channel % :blocks blocks})
           (keep (fn [{:strs [is_member id]}]
                   ;; TODO ensure bot joins team-channels when they are created
                   (when is_member id))
-                (get (slack/web-api "channels.list" {:slack/token token}) "channels")))))
+                (get (slack/web-api "channels.list" (:slack/token props)) "channels")))))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -39,62 +37,62 @@
 (defn block-actions
   "Handler for specific block actions.
   Branches on the bespoke action ID (set in server.slack.screens)."
-  [{:keys [slack/token]} payload]
-  (log/info "[block-actions!] payload" payload)
+  [props payload]
+  (log/debug "[block-actions!] payload" payload)
   (let [view-id (get-in payload [:container :view_id])]
     (case (-> payload :actions first :action_id)
       "admin:team-broadcast"
       (case (get-in payload [:view :type])
-        "home" (slack/web-api "views.open" {:trigger_id (:trigger_id payload)
-                                            :view (hiccup/->blocks-json (screens/team-broadcast-modal-compose))
-                                            :slack/token token})
-        "modal" (slack/web-api "views.update" {:view_id view-id
-                                               :view (hiccup/->blocks-json (screens/team-broadcast-modal-compose))
-                                               :slack/token token}))
-
+        "home" (slack/web-api "views.open" (:slack/token props)
+                              {:trigger_id (:trigger_id payload)
+                               :view (hiccup/->blocks-json (screens/team-broadcast-modal-compose))})
+        "modal" (slack/web-api "views.update" (:slack/token props)
+                               {:view_id view-id
+                                :view (hiccup/->blocks-json (screens/team-broadcast-modal-compose))}))
+      
       "user:team-broadcast-response"
-      (slack/web-api "views.open" {:trigger_id (:trigger_id payload)
-                                   :view (hiccup/->blocks-json
-                                           (screens/team-broadcast-response (->> payload
-                                                                                 :message
-                                                                                 :blocks last
-                                                                                 :elements first
-                                                                                 ;; text between brackets with lookahead/lookbehind:
-                                                                                 :text (re-find #"(?<=\[).+?(?=\])"))))
-                                   :slack/token token})
+      (slack/web-api "views.open" (:slack/token props)
+                     {:trigger_id (:trigger_id payload)
+                      :view (hiccup/->blocks-json
+                             (screens/team-broadcast-response (->> payload
+                                                                   :message
+                                                                   :blocks last
+                                                                   :elements first
+                                                                   ;; text between brackets with lookahead/lookbehind:
+                                                                   :text (re-find #"(?<=\[).+?(?=\])"))))})
 
       "user:team-broadcast-response-status"
-      (slack/web-api "views.update" {:view_id view-id
-                                     :view (hiccup/->blocks-json
-                                             (screens/team-broadcast-response-status
-                                               (get-in payload [:view :private_metadata])))
-                                     :slack/token token})
+      (slack/web-api "views.update" (:slack/token props)
+                     {:view_id view-id
+                      :view (hiccup/->blocks-json
+                             (screens/team-broadcast-response-status
+                              (get-in payload [:view :private_metadata])))})
       "user:team-broadcast-response-achievement"
-      (slack/web-api "views.update" {:view_id view-id
-                                     :view (hiccup/->blocks-json
-                                             (screens/team-broadcast-response-achievement
-                                               (get-in payload [:view :private_metadata])))
-                                     :slack/token token})
+      (slack/web-api "views.update" 
+                     (:slack/token props) {:view_id view-id
+                                           :view (hiccup/->blocks-json
+                                                  (screens/team-broadcast-response-achievement
+                                                   (get-in payload [:view :private_metadata])))})
       "user:team-broadcast-response-help"
-      (slack/web-api "views.update" {:view_id view-id
-                                     :view (hiccup/->blocks-json
-                                             (screens/team-broadcast-response-help
-                                               (get-in payload [:view :private_metadata])))
-                                     :slack/token token})
+      (slack/web-api "views.update" (:slack/token props)
+                     {:view_id view-id
+                      :view (hiccup/->blocks-json
+                             (screens/team-broadcast-response-help
+                              (get-in payload [:view :private_metadata])))})
 
       "broadcast2:channel-select"                           ;; refresh same view then save selection in private metadata
-      (slack/web-api "views.update" {:view_id view-id
-                                     :view (hiccup/->blocks-json
-                                             (screens/team-broadcast-modal-compose (-> payload :actions first :selected_conversation)))
-                                     :slack/token token})
+      (slack/web-api "views.update" (:slack/token props)
+                     {:view_id view-id
+                      :view (hiccup/->blocks-json
+                             (screens/team-broadcast-modal-compose (-> payload :actions first :selected_conversation)))})
 
       ;; Default: failure XXX `throw`?
       (log/error [:unhandled-block-action (-> payload :actions first :action-id)]))))
 
 (defn submission
   "Handler for 'Submit' press on any Slack modal."
-  [{:keys [slack/token]} payload]
-  (log/info "[submission!] payload:" payload)
+  [props payload]
+  (log/debug "[submission!] payload:" payload)
   (let [state (get-in payload [:view :state :values])]
     (cond
       ;; Admin broadcast: request for project update
@@ -107,7 +105,7 @@
       (or (-> state :sb-project-status1 :user:status-input)
           (-> state :sb-project-achievement1 :user:achievement-input)
           (-> state :sb-project-help1 :user:help-input))
-      (slack/web-api "chat.postMessage"
+      (slack/web-api "chat.postMessage" (:slack/token props)
                      {:blocks (hiccup/->blocks-json
                                 (screens/team-broadcast-response-msg
                                   "FIXME TODO project"
@@ -116,8 +114,7 @@
                                           (get-in state [:sb-project-help1 :user:help-input]))
                                       :value
                                       decode-text-input)))
-                      :channel (get-in payload [:view :private_metadata])
-                      :slack/token token}))))
+                      :channel (get-in payload [:view :private_metadata])}))))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -127,25 +124,39 @@
   "Slack Event"
   [props evt]
   (tap> ["[handle/event] evt:" evt])
+  (log/debug "[event] props:" props)
   (case (get evt :type)
-    "app_home_opened" (slack/web-api "views.publish"
+    "app_home_opened" (slack/web-api "views.publish" (:slack/token props)
                                      {:user_id (:slack/user-id props)
-                                      :view (hiccup/->blocks-json (screens/home {} ;; FIXME props
-                                                                                ))
-                                      :slack/token (:slack/token props)})
+                                      :view (hiccup/->blocks-json (screens/home props))})
     nil))
 
-(defn interaction
-  "Slack Interaction (e.g. global shortcut or modal)"
+(defn event-or-challenge
+  "Slack Event or URL confirmation challenge"
+  [{:as req :keys [params]}]
+  (if-let [challenge (:challenge params)]
+    (http/ok challenge)
+    (do ;; Fire off our complete response asynchronously
+      (future (let [evt (get-in req [:params :event])
+                    app-id (get-in common/config [:slack :app-id])
+                    team-id (:team_id params)]
+                (event #:slack{:app-id  app-id
+                               :team-id team-id
+                               :user-id (:user evt)
+                               :token   (get-in (slack-db/linked-team team-id) ;; ~600ms
+                                                [:app (keyword app-id) :bot-token])}
+                       evt)))
+      ;; Acknowledge the request immediately
+      (http/ok))))
+
+(defn interaction*
+  "Slack Interaction (e.g. global shortcut or modal) handler"
   [props payload]
-  (tap> ["[handle/interaction]" (:type payload) payload])
   (case (:type payload)
     ;; Slack "Global shortcut"
-    ;; TODO `future`?
-    "shortcut" (slack/web-api "views.open"
+    "shortcut" (slack/web-api "views.open" (:slack/token props)
                               {:trigger_id (:trigger_id payload)
-                               ;; FIXME `props` not empty map:
-                               :view (hiccup/->blocks-json (screens/shortcut-modal {}))})
+                               :view (hiccup/->blocks-json (screens/shortcut-modal props))})
 
     ;; ;; User acted on existing view
     "block_actions" (block-actions props payload)
@@ -156,37 +167,17 @@
     ;; TODO throw?
     (log/error [:unhandled-event (:type payload)])))
 
-(defn incoming
-  "All-purpose handler for Slack requests"
+(defn interaction
+  "Parsing request for Slack interactions handler"
   [{:as req :keys [params]}]
-  (log/info "[incoming] =====================================================================")
-  ;(log/info "[incoming] request:" req)
-  ;; TODO verify that requests come from Slack https://api.slack.com/authentication/verifying-requests-from-slack
-  (let [[kind data team-id user-id] (cond (:challenge params)
-                                          [:challenge (:challenge params)]
-
-                                          (:event params)
-                                          (let [event (:event params)]
-                                            [:event event (:team_id params) (:user event)])
-
-                                          (:payload params)
-                                          (let [payload (json->clj (:payload params))]
-                                            [:interaction
-                                             payload
-                                             (get-in payload [:team :id])
-                                             (get-in payload [:user :id])])
-                                          ;; Has not yet been required:
-                                          :else (log/error [:unhandled-request req]))
-        app-id (-> common/config :slack :app-id)
-        team (slack-db/linked-team team-id)
-        props #:slack{:app-id app-id
-                      :team-id team-id
-                      :user-id user-id
-                      :token (get-in team [:app (keyword app-id) :bot-token])}]
-    (case kind :challenge (http/ok data)
-               :event (do (future (event props data))
-                          (http/ok))
-               :interaction (do (future (interaction props data))
-                                ;; Submissions require an empty body
-                                (http/ok))
-               :else (log/error [:unhandled-request req]))))
+  #_ (tap> ["[handle/interaction]" (:type payload) payload])
+  (future (let [payload (json->clj (:payload params))
+                app-id  (get-in common/config [:slack :app-id])
+                team-id (get-in payload [:team :id])]
+            (interaction* #:slack{:app-id  app-id
+                                  :team-id team-id
+                                  :user-id (get-in payload [:user :id])
+                                  :token   (get-in (slack-db/linked-team team-id) ;; ~600ms
+                                                   [:app (keyword app-id) :bot-token])}
+                          payload)))
+  (http/ok))

--- a/src/org/sparkboard/server/handle.clj
+++ b/src/org/sparkboard/server/handle.clj
@@ -19,16 +19,16 @@
   ;; input, specifically replacing spaces with `+`
   (string/replace s "+" " "))
 
-(defn request-updates [props msg reply-channel]
+(defn request-updates [context msg reply-channel]
   ;; TODO Write broadcast to Firebase
   (log/debug "[request-updates] msg:" msg)
   (let [blocks (hiccup/->blocks-json (screens/team-broadcast-message msg reply-channel))]
-    (mapv #(slack/web-api "chat.postMessage" (:slack/token props)
+    (mapv #(slack/web-api "chat.postMessage" (:slack/token context)
                           {:channel % :blocks blocks})
           (keep (fn [{:strs [is_member id]}]
                   ;; TODO ensure bot joins team-channels when they are created
                   (when is_member id))
-                (get (slack/web-api "channels.list" (:slack/token props)) "channels")))))
+                (get (slack/web-api "channels.list" (:slack/token context)) "channels")))))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -37,21 +37,21 @@
 (defn block-actions
   "Handler for specific block actions.
   Branches on the bespoke action ID (set in server.slack.screens)."
-  [props payload]
+  [context payload]
   (log/debug "[block-actions!] payload" payload)
   (let [view-id (get-in payload [:container :view_id])]
     (case (-> payload :actions first :action_id)
       "admin:team-broadcast"
       (case (get-in payload [:view :type])
-        "home" (slack/web-api "views.open" (:slack/token props)
+        "home" (slack/web-api "views.open" (:slack/token context)
                               {:trigger_id (:trigger_id payload)
                                :view (hiccup/->blocks-json (screens/team-broadcast-modal-compose))})
-        "modal" (slack/web-api "views.update" (:slack/token props)
+        "modal" (slack/web-api "views.update" (:slack/token context)
                                {:view_id view-id
                                 :view (hiccup/->blocks-json (screens/team-broadcast-modal-compose))}))
       
       "user:team-broadcast-response"
-      (slack/web-api "views.open" (:slack/token props)
+      (slack/web-api "views.open" (:slack/token context)
                      {:trigger_id (:trigger_id payload)
                       :view (hiccup/->blocks-json
                              (screens/team-broadcast-response (->> payload
@@ -62,26 +62,26 @@
                                                                    :text (re-find #"(?<=\[).+?(?=\])"))))})
 
       "user:team-broadcast-response-status"
-      (slack/web-api "views.update" (:slack/token props)
+      (slack/web-api "views.update" (:slack/token context)
                      {:view_id view-id
                       :view (hiccup/->blocks-json
                              (screens/team-broadcast-response-status
                               (get-in payload [:view :private_metadata])))})
       "user:team-broadcast-response-achievement"
       (slack/web-api "views.update" 
-                     (:slack/token props) {:view_id view-id
+                     (:slack/token context) {:view_id view-id
                                            :view (hiccup/->blocks-json
                                                   (screens/team-broadcast-response-achievement
                                                    (get-in payload [:view :private_metadata])))})
       "user:team-broadcast-response-help"
-      (slack/web-api "views.update" (:slack/token props)
+      (slack/web-api "views.update" (:slack/token context)
                      {:view_id view-id
                       :view (hiccup/->blocks-json
                              (screens/team-broadcast-response-help
                               (get-in payload [:view :private_metadata])))})
 
       "broadcast2:channel-select"                           ;; refresh same view then save selection in private metadata
-      (slack/web-api "views.update" (:slack/token props)
+      (slack/web-api "views.update" (:slack/token context)
                      {:view_id view-id
                       :view (hiccup/->blocks-json
                              (screens/team-broadcast-modal-compose (-> payload :actions first :selected_conversation)))})
@@ -91,13 +91,13 @@
 
 (defn submission
   "Handler for 'Submit' press on any Slack modal."
-  [props payload]
+  [context payload]
   (log/debug "[submission!] payload:" payload)
   (let [state (get-in payload [:view :state :values])]
     (cond
       ;; Admin broadcast: request for project update
       (-> state :sb-input1 :broadcast2:text-input)
-      (request-updates props
+      (request-updates context
                        (decode-text-input (get-in state [:sb-input1 :broadcast2:text-input :value]))
                        (get-in payload [:view :private_metadata]))
 
@@ -105,7 +105,7 @@
       (or (-> state :sb-project-status1 :user:status-input)
           (-> state :sb-project-achievement1 :user:achievement-input)
           (-> state :sb-project-help1 :user:help-input))
-      (slack/web-api "chat.postMessage" (:slack/token props)
+      (slack/web-api "chat.postMessage" (:slack/token context)
                      {:blocks (hiccup/->blocks-json
                                (screens/team-broadcast-response-msg
                                 "FIXME TODO project"
@@ -122,29 +122,29 @@
 
 (defn event
   "Slack Event"
-  [props evt]
+  [context evt]
   (tap> ["[handle/event] evt:" evt])
-  (log/debug "[event] props:" props)
+  (log/debug "[event] context:" context)
   (case (get evt :type)
-    "app_home_opened" (slack/web-api "views.publish" (:slack/token props)
-                                     {:user_id (:slack/user-id props)
-                                      :view (hiccup/->blocks-json (screens/home props))})
+    "app_home_opened" (slack/web-api "views.publish" (:slack/token context)
+                                     {:user_id (:slack/user-id context)
+                                      :view (hiccup/->blocks-json (screens/home context))})
     nil))
 
 (defn interaction
   "Slack Interaction (e.g. global shortcut or modal) handler"
-  [props payload]
+  [context payload]
   (case (:type payload)
     ;; Slack "Global shortcut"
-    "shortcut" (slack/web-api "views.open" (:slack/token props)
+    "shortcut" (slack/web-api "views.open" (:slack/token context)
                               {:trigger_id (:trigger_id payload)
-                               :view (hiccup/->blocks-json (screens/shortcut-modal props))})
+                               :view (hiccup/->blocks-json (screens/shortcut-modal context))})
 
     ;; ;; User acted on existing view
-    "block_actions" (block-actions props payload)
+    "block_actions" (block-actions context payload)
 
     ;; "Submit" button pressed; modal submitted
-    "view_submission" (submission props payload)
+    "view_submission" (submission context payload)
 
     ;; TODO throw?
     (log/error [:unhandled-event (:type payload)])))
@@ -172,15 +172,15 @@
                                           :else (log/error [:unhandled-request req]))
         app-id (-> common/config :slack :app-id)
         team (slack-db/linked-team team-id)
-        props #:slack{:app-id app-id
+        context #:slack{:app-id app-id
                       :team-id team-id
                       :user-id user-id
                       :token (get-in team [:app (keyword app-id) :bot-token])}]
     (case kind
       :challenge    (http/ok data)
-      :event        (do (future (event props data))
+      :event        (do (future (event context data))
                         (http/ok))
-      :interaction  (do (future (interaction props data))
+      :interaction  (do (future (interaction context data))
                         ;; Submissions require an empty body
                         (http/ok))
       :else         (log/error [:unhandled-request req]))))

--- a/src/org/sparkboard/server/server.clj
+++ b/src/org/sparkboard/server/server.clj
@@ -15,8 +15,7 @@
 (def routes
   ;; TODO provide separate URLs where Slack allows, so we can pass to
   ;; individual handlers here rather than by examining the request
-  ["/" {"event"       handle/event-or-challenge
-        "interaction" handle/interaction}])
+  ["/" handle/incoming])
 
 (def app
   (-> (bidi.ring/make-handler routes)

--- a/src/org/sparkboard/server/server.clj
+++ b/src/org/sparkboard/server/server.clj
@@ -15,7 +15,8 @@
 (def routes
   ;; TODO provide separate URLs where Slack allows, so we can pass to
   ;; individual handlers here rather than by examining the request
-  ["/" handle/incoming])
+  ["/" {"event"       handle/event-or-challenge
+        "interaction" handle/interaction}])
 
 (def app
   (-> (bidi.ring/make-handler routes)

--- a/src/org/sparkboard/server/slack/core.clj
+++ b/src/org/sparkboard/server/slack/core.clj
@@ -24,11 +24,11 @@
 ;; TODO consider wrapping Java11+ API further
 (defn web-api
   ;; because `clj-http` fails to properly pass JSON bodies - it does some unwanted magic internally
-  ([family-method token]
+  ([family-method config]
    (let [request (-> (HttpRequest/newBuilder)
                      (.uri (URI/create (str "https://slack.com/api/" family-method)))
                      (.header "Content-Type" "application/json; charset=utf-8")
-                     (.header "Authorization" (str "Bearer " token))
+                     (.header "Authorization" (str "Bearer " (:auth/token config)))
                      (.GET)
                      (.build))
          clnt (-> (HttpClient/newBuilder)
@@ -37,12 +37,12 @@
          rsp (.body (.send clnt request (HttpResponse$BodyHandlers/ofString)))]
      (log/debug "[web-api] GET rsp:" rsp)
      (json/read-value rsp)))
-  ([family-method token body]
+  ([family-method config body]
    (log/debug "[web-api] body:" body)
    (let [request (-> (HttpRequest/newBuilder)
                      (.uri (URI/create (str "https://slack.com/api/" family-method)))
                      (.header "Content-Type" "application/json; charset=utf-8")
-                     (.header "Authorization" (str "Bearer " token))
+                     (.header "Authorization" (str "Bearer " (:auth/token config)))
                      (.POST (HttpRequest$BodyPublishers/ofString (json/write-value-as-string body)))
                      (.build))
          clnt (-> (HttpClient/newBuilder)

--- a/src/org/sparkboard/server/slack/screens.clj
+++ b/src/org/sparkboard/server/slack/screens.clj
@@ -5,7 +5,7 @@
   ;;           [org.sparkboard.slack.slack-db :as slack-db])
   )
 
-(defn main-menu [{:as props :keys [lambda/req slack/team-id]}]
+(defn main-menu [{:as context :keys [lambda/req slack/team-id]}]
   (list
     [:section
      {:accessory [:button {:style "primary",
@@ -21,9 +21,9 @@
                       {:slack/team-id team-id
                        :lambda/root (common/lambda-root-url req)})} "Reinstall App"]]))
 
-(defn home [props]
+(defn home [context]
   [:home
-   (main-menu props)
+   (main-menu context)
    [:section
     (str "_Last updated:_ " (rand-int 10000)
          ;; FIXME (-> (js/Date.)
@@ -31,9 +31,9 @@
          ;;                                  :timeStyle "medium"}))
          )]])
 
-(defn shortcut-modal [props]
+(defn shortcut-modal [context]
   [:modal {:title "Broadcast"
-           :blocks (main-menu props)}])
+           :blocks (main-menu context)}])
 
 (def team-broadcast-blocks
   (list


### PR DESCRIPTION
* separate Slack endpoints into Events and Interactions (this requires config change in Slack API dashboard)
* our API for the Slack API now takes the token second, after the `family.method`
* `props` are parsed from the request specific to the request type (Event/Interaction)
* props are passed in the first position