### PR TITLE
per-ns log-levels, tap option

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -21,9 +21,13 @@
         mhuebert/kitchen-async {:mvn/version "0.1.0"}
         net.cgrand/macrovich {:mvn/version "0.2.1"}
         yogsototh/clj-jwt {:mvn/version "0.3.0"}
-        com.taoensso/timbre {:mvn/version "4.10.0"}
         clj-http {:mvn/version "3.10.1"}
         lambdaisland/uri {:mvn/version "1.3.45"}
+
+        ;; logging
+        com.taoensso/timbre {:mvn/version "4.10.0"}
+        timbre-ns-pattern-level {:mvn/version "0.1.2"}
+        com.fzakaria/slf4j-timbre {:mvn/version "0.3.19"}
 
         ;; http server
         ring/ring-jetty-adapter {:mvn/version "1.8.1"}
@@ -31,7 +35,7 @@
         bidi {:mvn/version "2.1.6"}
         ring-middleware-format {:mvn/version "0.7.4"}
         metosin/ring-http-response {:mvn/version "0.9.1"}
-        
+
         ;; frontend
         thheller/shadow-cljs {:mvn/version "2.9.3"}
         mhuebert/triple {:mvn/version "0.1.0"}

--- a/src/org/sparkboard/firebase/jvm.clj
+++ b/src/org/sparkboard/firebase/jvm.clj
@@ -94,7 +94,6 @@
                (walk/stringify-keys value)
                (reify-completion-listener
                  (fn [error snap]
-                   (tap> {:error error :snap snap})
                    (if error
                      (throw (ex-info "Error setting firebase value"
                                      {:path path}
@@ -108,9 +107,8 @@
                      (walk/stringify-keys value)
                      (reify-completion-listener
                        (fn [error snap]
-                         (tap> {:error error :snap snap})
                          (if error
-                           (throw (ex-info "Error setting firebase value"
+                           (throw (ex-info "Error updating firebase value"
                                            {:path path}
                                            error))
                            (deliver p snap)))))

--- a/src/org/sparkboard/http.cljc
+++ b/src/org/sparkboard/http.cljc
@@ -8,7 +8,8 @@
        [org.sparkboard.js-convert :refer [->clj clj->json json->clj ->js]]
        [org.sparkboard.promise :as p]
        [clojure.string :as str]
-       [org.sparkboard.transit :as transit])
+       [org.sparkboard.transit :as transit]
+       [taoensso.timbre :as log])
      :clj
      (:require
        [org.sparkboard.js-convert :refer [->clj clj->json json->clj ->js]]
@@ -16,7 +17,8 @@
        [org.sparkboard.transit :as transit]
        [clj-http.client :as client]
        [clojure.string :as str]
-       [lambdaisland.uri :as uri]))
+       [lambdaisland.uri :as uri]
+       [taoensso.timbre :as log]))
   #?(:clj (:import (java.util Base64))))
 
 #?(:cljs
@@ -70,7 +72,7 @@
                body (format-req-body)
                true (dissoc :query :auth/token))
         url (cond-> url query (str "?" (uri/map->query-string query)))]
-    (tap> {url opts})
+    (log/trace :http-req {:url url :opts opts})
     (p/let [response #?(:cljs
                         (p/-> (fetch url (-> opts
                                              (cond-> body (assoc :body body))

--- a/src/org/sparkboard/util/future.clj
+++ b/src/org/sparkboard/util/future.clj
@@ -5,6 +5,6 @@
      (try
        ~@body
        (catch Exception e#
-         (tap> {:future/Exception e#}))
+         (~'taoensso.timbre/error :future/Exception e#))
        (catch java.lang.AssertionError e#
-         (tap> {:future/AssertionError e#})))))
+         (~'taoensso.timbre/error {:future/AssertionError e#})))))


### PR DESCRIPTION
- add `:dev.logging/tap?` and logs will be sent via `tap>` instead of printing to console (eg. works well with [shadow-cljs inspect](https://clojureverse.org/t/introducing-shadow-cljs-inspect/5012), which is as useful on jvm as cljs)
- configure logging per-namespace (or pattern)