### PR TITLE
Simplify Slack broadcast response flow

### DIFF
--- a/src/org/sparkboard/server/server.clj
+++ b/src/org/sparkboard/server/server.clj
@@ -99,12 +99,12 @@
       (slack/web-api "views.open" {:auth/token (:slack/bot-token context)}
                      {:trigger_id (:trigger_id payload)
                       :view (hiccup/->blocks-json
-                              (screens/team-broadcast-response (->> payload
-                                                                    :message
-                                                                    :blocks last
-                                                                    :elements first
-                                                                    ;; text between brackets with lookahead/lookbehind:
-                                                                    :text (re-find #"(?<=\[).+?(?=\])"))))})
+                             (screens/team-broadcast-response
+                              (->> payload :message :blocks first :text :text) ; broadcast msg
+                              (->> payload :message :blocks last
+                                   :elements first :text
+                                   ;; text between brackets with lookahead/lookbehind:
+                                   (re-find #"(?<=\[).+?(?=\])"))))})
 
       "broadcast2:channel-select"                           ;; refresh same view then save selection in private metadata
       (slack/web-api "views.update" {:auth/token (:slack/bot-token context)}

--- a/src/org/sparkboard/server/server.clj
+++ b/src/org/sparkboard/server/server.clj
@@ -83,7 +83,7 @@
   "Handler for specific block actions.
   Branches on the bespoke action ID (set in server.slack.screens)."
   [context payload]
-  (log/debug "[block-actions!] payload" payload)
+  (log/debug "[block-actions] payload" payload)
   (let [view-id (get-in payload [:container :view_id])]
     (case (-> payload :actions first :action_id)
       "admin:team-broadcast"
@@ -105,25 +105,6 @@
                                                                     :elements first
                                                                     ;; text between brackets with lookahead/lookbehind:
                                                                     :text (re-find #"(?<=\[).+?(?=\])"))))})
-
-      "user:team-broadcast-response-status"
-      (slack/web-api "views.update" {:auth/token (:slack/bot-token context)}
-                     {:view_id view-id
-                      :view (hiccup/->blocks-json
-                              (screens/team-broadcast-response-status
-                                (get-in payload [:view :private_metadata])))})
-      "user:team-broadcast-response-achievement"
-      (slack/web-api "views.update"
-                     {:auth/token (:slack/bot-token context)} {:view_id view-id
-                                                               :view (hiccup/->blocks-json
-                                                                       (screens/team-broadcast-response-achievement
-                                                                         (get-in payload [:view :private_metadata])))})
-      "user:team-broadcast-response-help"
-      (slack/web-api "views.update" {:auth/token (:slack/bot-token context)}
-                     {:view_id view-id
-                      :view (hiccup/->blocks-json
-                              (screens/team-broadcast-response-help
-                                (get-in payload [:view :private_metadata])))})
 
       "broadcast2:channel-select"                           ;; refresh same view then save selection in private metadata
       (slack/web-api "views.update" {:auth/token (:slack/bot-token context)}
@@ -510,4 +491,6 @@
   (restart-server! (or (some-> (System/getenv "PORT") (Integer/parseInt)) 3000)))
 
 (comment
-  (-main))
+  (-main)
+
+  )

--- a/src/org/sparkboard/server/slack/screens.clj
+++ b/src/org/sparkboard/server/slack/screens.clj
@@ -126,11 +126,11 @@
                  ;; refactor so don't have time now
                  :text (str "Responses will post to channel [" reply-channel "]")}]}))
 
-(defn team-broadcast-response [reply-channel] ;; TODO add parameter for existing message
-  [:modal {:title [:plain_text "Describe Current Status"]
+(defn team-broadcast-response [original-msg reply-channel]
+  [:modal {:title [:plain_text "Project Update"]
            :blocks [{:type "input",
                      :label {:type "plain_text",
-                             :text "Tell us what you've been working on:",
+                             :text original-msg,
                              :emoji true},
                      :block_id "sb-project-status1"
                      :element {:type "plain_text_input", :multiline true

--- a/src/org/sparkboard/server/slack/screens.clj
+++ b/src/org/sparkboard/server/slack/screens.clj
@@ -126,29 +126,7 @@
                  ;; refactor so don't have time now
                  :text (str "Responses will post to channel [" reply-channel "]")}]}))
 
-(defn team-broadcast-response [reply-channel]
-  [:modal {:title [:plain_text "Project Update"]
-           :blocks (list
-                     {:type "actions",
-                      :elements [[:button {:text {:type "plain_text",
-                                                  :text "Describe current status",
-                                                  :emoji true},
-                                           :action_id "user:team-broadcast-response-status"
-                                           :value "click_me_123"}]
-                                 [:button {:text {:type "plain_text",
-                                                  :text "Share achievement",
-                                                  :emoji true},
-                                           :action_id "user:team-broadcast-response-achievement"
-                                           :value "click_me_456"}]
-                                 [:button {:text {:type "plain_text",
-                                                  :text "Ask for help",
-                                                  :emoji true},
-                                           :action_id "user:team-broadcast-response-help"
-                                           :value "click_me_789"}]]})
-           :submit [:plain_text "Send"]
-           :private_metadata reply-channel}])
-
-(defn team-broadcast-response-status [private-metadata]
+(defn team-broadcast-response [reply-channel] ;; TODO add parameter for existing message
   [:modal {:title [:plain_text "Describe Current Status"]
            :blocks [{:type "input",
                      :label {:type "plain_text",
@@ -157,31 +135,7 @@
                      :block_id "sb-project-status1"
                      :element {:type "plain_text_input", :multiline true
                                :action_id "user:status-input"}}]
-           :private_metadata private-metadata
-           :submit [:plain_text "Send"]}])
-
-(defn team-broadcast-response-achievement [private-metadata]
-  [:modal {:title [:plain_text "Share Achievement"]
-           :blocks [{:type "input",
-                     :label {:type "plain_text",
-                             :text "Tell us about the milestone you reached:",
-                             :emoji true},
-                     :block_id "sb-project-achievement1"
-                     :element {:type "plain_text_input", :multiline true
-                               :action_id "user:achievement-input"}}]
-           :private_metadata private-metadata
-           :submit [:plain_text "Send"]}])
-
-(defn team-broadcast-response-help [private-metadata]
-  [:modal {:title [:plain_text "Request for Help"]
-           :blocks [{:type "input",
-                     :label {:type "plain_text",
-                             :text "Let us know what you could use help with. We'll try to lend a hand.",
-                             :emoji true},
-                     :block_id "sb-project-help1"
-                     :element {:type "plain_text_input", :multiline true
-                               :action_id "user:help-input"}}]
-           :private_metadata private-metadata
+           :private_metadata reply-channel
            :submit [:plain_text "Send"]}])
 
 (defn team-broadcast-response-msg [project msg]


### PR DESCRIPTION
Minor changes to the response part of Slack broadcast flow:
 - no intermediate modal to choose type of response (help/achievement)
 - include broadcast text in modal

Replaces #40 