### PR TITLE
Save broadcasts to firebase

### DIFF
--- a/src/org/sparkboard/server/server.clj
+++ b/src/org/sparkboard/server/server.clj
@@ -67,9 +67,9 @@
   (str/replace s "+" " "))
 
 (defn request-updates [context msg reply-channel]
-  (let [reply-channel-name (slack/channel-name reply-channel)]
-    (log/debug "[request-updates] msg:" msg)
-    (fire-jvm/set-value (.push (fire-jvm/->ref "/slack-broadcast"))
+  (let [reply-channel-name (slack/channel-name reply-channel)
+        firebase-ref (.push (fire-jvm/->ref "/slack-broadcast"))]
+    (fire-jvm/set-value firebase-ref
                         {:message msg
                          :reply-to {:channel-id reply-channel
                                     :reply-channel reply-channel-name}})
@@ -77,7 +77,9 @@
                           {:auth/token (:slack/bot-token context)}
                           {:channel (:channel-id %)
                            :blocks (hiccup/->blocks-json
-                                    (screens/team-broadcast-message msg reply-channel-name))})
+                                    (screens/team-broadcast-message msg
+                                                                    (.getKey firebase-ref)
+                                                                    reply-channel-name))})
           (slack-db/team->all-linked-channels (:slack/team-id context)))))
 
 
@@ -89,8 +91,10 @@
   Branches on the bespoke action ID (set in server.slack.screens)."
   [context payload]
   (log/debug "[block-actions] payload" payload)
-  (let [view-id (get-in payload [:container :view_id])]
-    (case (-> payload :actions first :action_id)
+  (let [view-id (get-in payload [:container :view_id])
+        [action-id firebase-key] (str/split (-> payload :actions first :action_id)
+                                            (re-pattern screens/action-id-separator))]
+    (case action-id
       "admin:team-broadcast"
       (case (get-in payload [:view :type])
         "home" (slack/web-api "views.open" {:auth/token (:slack/bot-token context)}
@@ -100,16 +104,17 @@
                                {:view_id view-id
                                 :view (hiccup/->blocks-json (screens/team-broadcast-modal-compose context))}))
 
-      "user:team-broadcast-response" ; user opens modal to respond to broadcast
-      (slack/web-api "views.open" {:auth/token (:slack/bot-token context)}
-                     {:trigger_id (:trigger_id payload)
-                      :view (hiccup/->blocks-json
-                             (screens/team-broadcast-response
-                              (->  payload :message :blocks first :text :text) ; broadcast msg
-                              (->> payload :message :blocks last
-                                   :elements first :text
-                                   ;; text between brackets with lookahead/lookbehind:
-                                   (re-find #"(?<=\[).+?(?=\])"))))})
+      "user:team-broadcast-response" ; "Post an Update" button (user opens modal to respond to broadcast)
+      (let [firebase-path (str "/slack-broadcast/" firebase-key)
+            firebase-child-ref (.push (fire-jvm/->ref (str firebase-path "/replies")))]
+        (fire-jvm/set-value firebase-child-ref
+                            {:responding-from-channel (-> payload :channel :name)})
+        (slack/web-api "views.open" {:auth/token (:slack/bot-token context)}
+                       {:trigger_id (:trigger_id payload)
+                        :view (hiccup/->blocks-json
+                               (screens/team-broadcast-response
+                                (->  payload :message :blocks first :text :text) ; broadcast msg
+                                (str firebase-path "/replies/" (.getKey firebase-child-ref))))}))
 
       "broadcast2:channel-select" ; refresh same view then save selection in private metadata
       (slack/web-api "views.update" {:auth/token (:slack/bot-token context)}
@@ -137,16 +142,17 @@
           (-> state :sb-project-achievement1 :user:achievement-input)
           (-> state :sb-project-help1 :user:help-input))
       (slack/web-api "chat.postMessage" {:auth/token (:slack/bot-token context)}
-                     {:blocks (hiccup/->blocks-json
-                               (screens/team-broadcast-response-msg
-                                (->  payload :user :name)
-                                "FIXME TODO project"
-                                (-> (or (get-in state [:sb-project-status1 :user:status-input])
-                                        (get-in state [:sb-project-achievement1 :user:achievement-input])
-                                        (get-in state [:sb-project-help1 :user:help-input]))
-                                    :value
-                                    decode-text-input)))
-                      :channel (get-in payload [:view :private_metadata])}))))
+                     (let [firebase-key (get-in payload [:view :private_metadata])]
+                       {:blocks (hiccup/->blocks-json
+                                 (screens/team-broadcast-response-msg
+                                  (->  payload :user :name)
+                                  (-> firebase-key fire-jvm/read :responding-from-channel)
+                                  (-> (or (get-in state [:sb-project-status1 :user:status-input])
+                                          (get-in state [:sb-project-achievement1 :user:achievement-input])
+                                          (get-in state [:sb-project-help1 :user:help-input]))
+                                      :value
+                                      decode-text-input)))
+                        :channel (:channel-id (:reply-to (fire-jvm/read (.getParent (.getParent (fire-jvm/->ref firebase-key))))))})))))
 
 (defn send-welcome-message! [context {:as user :keys [id]}]
   (let [url (urls/link-sparkboard-account context)]

--- a/src/org/sparkboard/server/server.clj
+++ b/src/org/sparkboard/server/server.clj
@@ -67,7 +67,7 @@
   (str/replace s "+" " "))
 
 (defn request-updates [context msg reply-channel]
-  (let [reply-channel-name (slack/channel-name reply-channel)
+  (let [reply-channel-name (slack/channel-name reply-channel (:slack/bot-token context))
         firebase-ref (.push (fire-jvm/->ref "/slack-broadcast"))]
     (fire-jvm/set-value firebase-ref
                         {:message msg

--- a/src/org/sparkboard/server/server.clj
+++ b/src/org/sparkboard/server/server.clj
@@ -100,18 +100,18 @@
                                {:view_id view-id
                                 :view (hiccup/->blocks-json (screens/team-broadcast-modal-compose context))}))
 
-      "user:team-broadcast-response"
+      "user:team-broadcast-response" ; user opens modal to respond to broadcast
       (slack/web-api "views.open" {:auth/token (:slack/bot-token context)}
                      {:trigger_id (:trigger_id payload)
                       :view (hiccup/->blocks-json
                              (screens/team-broadcast-response
-                              (->> payload :message :blocks first :text :text) ; broadcast msg
+                              (->  payload :message :blocks first :text :text) ; broadcast msg
                               (->> payload :message :blocks last
                                    :elements first :text
                                    ;; text between brackets with lookahead/lookbehind:
                                    (re-find #"(?<=\[).+?(?=\])"))))})
 
-      "broadcast2:channel-select"                           ;; refresh same view then save selection in private metadata
+      "broadcast2:channel-select" ; refresh same view then save selection in private metadata
       (slack/web-api "views.update" {:auth/token (:slack/bot-token context)}
                      {:view_id view-id
                       :view (hiccup/->blocks-json
@@ -138,13 +138,14 @@
           (-> state :sb-project-help1 :user:help-input))
       (slack/web-api "chat.postMessage" {:auth/token (:slack/bot-token context)}
                      {:blocks (hiccup/->blocks-json
-                                (screens/team-broadcast-response-msg
-                                  "FIXME TODO project"
-                                  (-> (or (get-in state [:sb-project-status1 :user:status-input])
-                                          (get-in state [:sb-project-achievement1 :user:achievement-input])
-                                          (get-in state [:sb-project-help1 :user:help-input]))
-                                      :value
-                                      decode-text-input)))
+                               (screens/team-broadcast-response-msg
+                                (->  payload :user :name)
+                                "FIXME TODO project"
+                                (-> (or (get-in state [:sb-project-status1 :user:status-input])
+                                        (get-in state [:sb-project-achievement1 :user:achievement-input])
+                                        (get-in state [:sb-project-help1 :user:help-input]))
+                                    :value
+                                    decode-text-input)))
                       :channel (get-in payload [:view :private_metadata])}))))
 
 (defn send-welcome-message! [context {:as user :keys [id]}]

--- a/src/org/sparkboard/server/slack/core.clj
+++ b/src/org/sparkboard/server/slack/core.clj
@@ -67,10 +67,9 @@
 
 (def channel-name
   (memoize
-   (fn [channel-id]
+   (fn [channel-id token]
      (get (into {}
                 (map (juxt :id :name_normalized)
                      (:channels (web-api "channels.list"
-                                         {:auth/token (-> env/config :slack
-                                                          :bot-user-oauth-token)}))))
+                                         {:auth/token token}))))
           channel-id))))

--- a/src/org/sparkboard/server/slack/core.clj
+++ b/src/org/sparkboard/server/slack/core.clj
@@ -2,6 +2,7 @@
   (:require [clj-http.client :as client]
             [jsonista.core :as json]
             [org.sparkboard.js-convert :refer [json->clj]]
+            [org.sparkboard.server.env :as env]
             [taoensso.timbre :as log])
   (:import [java.net.http HttpClient HttpRequest HttpClient$Version HttpRequest$BodyPublishers HttpResponse$BodyHandlers]
            [java.net URI]))
@@ -59,10 +60,17 @@
      (log/debug "[web-api] POST rsp:" rsp)
      rsp)))
 
-;; TODO "when a new member joins a project, add them to the linked channel"
-
 (comment
   (http-verb "/users.list")
-  
-  ;; TODO delete/archive channel, for testing and clean-up
+
   )
+
+(def channel-name
+  (memoize
+   (fn [channel-id]
+     (get (into {}
+                (map (juxt :id :name_normalized)
+                     (:channels (web-api "channels.list"
+                                         {:auth/token (-> env/config :slack
+                                                          :bot-user-oauth-token)}))))
+          channel-id))))

--- a/src/org/sparkboard/server/slack/screens.clj
+++ b/src/org/sparkboard/server/slack/screens.clj
@@ -109,7 +109,7 @@
                   ;; See https://api.slack.com/reference/surfaces/views
                   (when private-data {:private_metadata private-data}))]))
 
-(defn team-broadcast-message [msg reply-channel]
+(defn team-broadcast-message [msg reply-channel-name]
   (list
     [:section {:text {:type "mrkdwn" :text msg}}]
     {:type "actions",
@@ -121,10 +121,7 @@
                           :value "click_me_123"}]]}
     {:type "context",
      :elements [{:type "mrkdwn",
-                 ;; TODO make `reply-channel` a human-readable channel
-                 ;; name; `db` namespace was broken in an earlier
-                 ;; refactor so don't have time now
-                 :text (str "Responses will post to channel [" reply-channel "]")}]}))
+                 :text (str "Responses will post to channel [" reply-channel-name "]")}]}))
 
 (defn team-broadcast-response [original-msg reply-channel]
   [:modal {:title [:plain_text "Project Update"]

--- a/src/org/sparkboard/server/slack/screens.clj
+++ b/src/org/sparkboard/server/slack/screens.clj
@@ -4,6 +4,8 @@
             [org.sparkboard.server.slack.core :as slack]
             [org.sparkboard.server.slack.hiccup :as hiccup]))
 
+(def action-id-separator "::")
+
 (defn main-menu [context]
   (list
     [:section
@@ -109,7 +111,9 @@
                   ;; See https://api.slack.com/reference/surfaces/views
                   (when private-data {:private_metadata private-data}))]))
 
-(defn team-broadcast-message [msg reply-channel-name]
+(defn team-broadcast-message
+  "Administrator broadcast to project channels, soliciting project update responses."
+  [msg firebase-key reply-channel-name]
   (list
     [:section {:text {:type "mrkdwn" :text msg}}]
     {:type "actions",
@@ -117,13 +121,17 @@
                           :text {:type "plain_text",
                                  :text "Post an Update",
                                  :emoji true},
-                          :action_id "user:team-broadcast-response"
+                          :action_id (str "user:team-broadcast-response"
+                                          action-id-separator
+                                          firebase-key)
                           :value "click_me_123"}]]}
     {:type "context",
      :elements [{:type "mrkdwn",
                  :text (str "Responses will post to channel [" reply-channel-name "]")}]}))
 
-(defn team-broadcast-response [original-msg reply-channel]
+(defn team-broadcast-response
+  "User response to broadcast - text field for project status update"
+  [original-msg firebase-key]
   [:modal {:title [:plain_text "Project Update"]
            :blocks [{:type "input",
                      :label {:type "plain_text",
@@ -132,7 +140,7 @@
                      :block_id "sb-project-status1"
                      :element {:type "plain_text_input", :multiline true
                                :action_id "user:status-input"}}]
-           :private_metadata reply-channel
+           :private_metadata firebase-key
            :submit [:plain_text "Send"]}])
 
 (defn team-broadcast-response-msg [replying-user project msg]

--- a/src/org/sparkboard/server/slack/screens.clj
+++ b/src/org/sparkboard/server/slack/screens.clj
@@ -135,10 +135,11 @@
            :private_metadata reply-channel
            :submit [:plain_text "Send"]}])
 
-(defn team-broadcast-response-msg [project msg]
+(defn team-broadcast-response-msg [replying-user project msg]
   [{:type "divider"}
    {:type "section",
-    :text {:type "mrkdwn", :text (str "_Project:_ * " project "*")}}
+    :text {:type "mrkdwn", :text (str "_Project:_ * " project "*, "
+                                      "_User:_ * " replying-user "*")}}
    {:type "section",
     :text {:type "plain_text", :text msg, :emoji true}}
    #_{:type "actions",


### PR DESCRIPTION
Saves broadcasts and replies to firebase. We store the firebase key (first parent/broadcast, then child/reply) in private metadata except when we're forced to put it in an `action_id` after a separator. 

I used that to (finally) put the project/channel name in the broadcast reply, and while I was there it seemed useful to include the replying user as well.