### PR TITLE
organize handlers into a map, try for nicer state handling in modals

### DIFF
--- a/src/org/sparkboard/js_convert.cljc
+++ b/src/org/sparkboard/js_convert.cljc
@@ -46,5 +46,3 @@
 (comment
   (->clj (->js {:slack/id 1})))
 
-(defn update-json [json f & args]
-  (clj->json (apply f (json->clj json) args)))

--- a/src/org/sparkboard/server/server.clj
+++ b/src/org/sparkboard/server/server.clj
@@ -276,7 +276,7 @@
         (let [{:keys [slack/bot-token]} (team-context team-id)
               domain (-> (http/get+ (str slack/base-uri "team.info")
                                     {:query {:token bot-token
-                                             :team "T014098L9FD"}})
+                                             :team team-id}})
                          (slack-ok! 500 "Could not read team info")
                          :team :domain)]
           (if invite-link

--- a/src/org/sparkboard/server/slack/core.clj
+++ b/src/org/sparkboard/server/slack/core.clj
@@ -40,7 +40,7 @@
         rsp (json->clj (.body (.send clnt request (HttpResponse$BodyHandlers/ofString))))]
     (log/debug "[web-api] GET rsp:" rsp)
     (when-not (:ok rsp)
-      (throw (ex-info (str "web-api failure: slack/" family-method) {:rsp rsp :config config})))
+      (throw (ex-info (str "web-api failure: slack/" family-method) {:rsp rsp :config config :query-map query-map})))
     rsp))
 
 (defn web-api-post
@@ -57,7 +57,7 @@
                  (.build))
         rsp (json->clj (.body (.send clnt request (HttpResponse$BodyHandlers/ofString))))]
     (when-not (:ok rsp)
-      (throw (ex-info (str "web-api failure: slack/" family-method) {:rsp rsp :config config})))
+      (throw (ex-info (str "web-api failure: slack/" family-method) {:rsp rsp :config config :body body})))
     (log/debug "[web-api] POST rsp:" rsp)
     rsp))
 

--- a/src/org/sparkboard/server/slack/core.clj
+++ b/src/org/sparkboard/server/slack/core.clj
@@ -4,20 +4,23 @@
             [lambdaisland.uri]
             [org.sparkboard.js-convert :refer [json->clj]]
             [org.sparkboard.server.env :as env]
+            [org.sparkboard.server.slack.hiccup :as hiccup]
             [taoensso.timbre :as log])
   (:import [java.net.http HttpClient HttpRequest
-            HttpClient$Version
-            HttpRequest$BodyPublishers
-            HttpResponse$BodyHandlers]
+                          HttpClient$Version
+                          HttpRequest$BodyPublishers
+                          HttpResponse$BodyHandlers]
            [java.net URI]))
+
+(def ^:dynamic *request* {})
 
 (def base-uri "https://slack.com/api/")
 
 (defonce ^{:doc "Slack Web API RPC specification"
            :lookup-ts (java.time.LocalDateTime/now (java.time.ZoneId/of "UTC"))}
-  web-api-spec
+         web-api-spec
          (delay
-           (json/read-value (slurp ; canonical URL per https://api.slack.com/web#basics#spec
+           (json/read-value (slurp                          ; canonical URL per https://api.slack.com/web#basics#spec
                               "https://api.slack.com/specs/openapi/v2/slack_web.json"))))
 
 ;; TODO consider https://github.com/gnarroway/hato
@@ -40,6 +43,7 @@
         rsp (json->clj (.body (.send clnt request (HttpResponse$BodyHandlers/ofString))))]
     (log/debug "[web-api] GET rsp:" rsp)
     (when-not (:ok rsp)
+      (log/error (-> rsp :response_metadata :messages))
       (throw (ex-info (str "web-api failure: slack/" family-method) {:rsp rsp :config config :query-map query-map})))
     rsp))
 
@@ -57,6 +61,7 @@
                  (.build))
         rsp (json->clj (.body (.send clnt request (HttpResponse$BodyHandlers/ofString))))]
     (when-not (:ok rsp)
+      (tap> (-> rsp :response_metadata :messages))
       (throw (ex-info (str "web-api failure: slack/" family-method) {:rsp rsp :config config :body body})))
     (log/debug "[web-api] POST rsp:" rsp)
     rsp))
@@ -67,14 +72,16 @@
                         ["paths" (if-not (#{\/} (first family-method))
                                    (str "/" family-method)
                                    family-method)]))
-    "get"  web-api-get
+    "get" web-api-get
     "post" web-api-post))
 
 (defn web-api
   ;; We use java HTTP client because `clj-http` fails to properly pass
   ;; JSON bodies - it does some unwanted magic internally.
-  [family-method config params]
-  ((http-verb family-method) family-method config params))
+  ([family-method params]
+   (web-api family-method {:auth/token (:slack/bot-token *request*)} params))
+  ([family-method config params]
+   ((http-verb family-method) family-method config params)))
 
 (def channel-info
   (memoize
@@ -82,19 +89,39 @@
       (-> (web-api "conversations.info" {:auth/token token} {:channel channel-id})
           :channel))))
 
-(defn user-info [{:keys [slack/user-id slack/bot-token]}]
-  (-> (web-api "users.info" {} {:user user-id
-                                :token bot-token})
+(defn user-info [{:slack/keys [user-id bot-token]}]
+  (-> (web-api "users.info" {:auth/token bot-token} {:user user-id})
       :user))
+
+;;;;;;;;;;;;;;;;;;;;;
+;; views endpoints, wrwapped to include hash + trigger_id from context
+
+(defn- views
+  ([options blocks]
+   (web-api (str "views." (:action options))
+            (merge {:view (hiccup/->blocks-json blocks)}
+                   (some->> (:slack/trigger-id *request*)
+                            (hash-map :trigger_id))
+                   (when (:view_id options)
+                     {:view_id (:view_id options)
+                      :hash (:slack/view-hash *request*)})))))
+
+(defn views-open [blocks]
+  (views {:action "open"} blocks))
+(defn views-push [blocks]
+  (views {:action "push"} blocks))
+(defn views-update [view-id blocks]
+  (views {:action "update"
+          :view_id view-id} blocks))
 
 (comment
   (http-verb "users.list")
 
-  (http-verb "conversations.info") ; #function[org.sparkboard.server.slack.core/web-api-get]
+  (http-verb "conversations.info")                          ; #function[org.sparkboard.server.slack.core/web-api-get]
 
   (http-verb "channels.list")
 
-  (http-verb "views.publish") ;; XXX this seems to be a mistake on Slack's part: it's GET in the spec but POST in the docs
+  (http-verb "views.publish")                               ;; XXX this seems to be a mistake on Slack's part: it's GET in the spec but POST in the docs
 
   ;; bot token only for local dev experiments
   (web-api-get "conversations.info" {:auth/token (-> env/config :slack :bot-user-oauth-token)})

--- a/src/org/sparkboard/server/slack/hiccup.cljc
+++ b/src/org/sparkboard/server/slack/hiccup.cljc
@@ -1,7 +1,7 @@
 (ns org.sparkboard.server.slack.hiccup
   (:require [clojure.string :as str]
-            [org.sparkboard.transit :as transit]
-            [org.sparkboard.js-convert :refer [clj->json kw->js]]))
+            [org.sparkboard.js-convert :refer [clj->json kw->js]]
+            [org.sparkboard.transit :as transit]))
 
 (def schema
   "hiccup<->block metadata. Supports:
@@ -31,7 +31,13 @@
                       :hint :plain_text}
             :child :element}
    "context" {:children :elements}
-   "plain_text_input" {:strings {:placeholder :plain_text}}})
+   "users_select" {:strings {:placeholder :plain_text}}
+   "plain_text_input" {:strings {:placeholder :plain_text}}
+   "multi_static_select" {:strings {:placeholder :plain_text}}
+   "multi_users_select" {:strings {:placeholder :plain_text}}
+   "multi_external_select" {:strings {:placeholder :plain_text}}
+   "multi_conversations_select" {:strings {:placeholder :plain_text}}
+   "multi_channels_select" {:strings {:placeholder :plain_text}}})
 
 
 (declare ->blocks)
@@ -93,6 +99,9 @@
 
 (defn hiccup? [form] (and (vector? form) (keyword? (first form))))
 
+(defn kw->underscore [k]
+  (str/replace (name k) "-" "_"))
+
 (defn ->blocks
   "Converts hiccup to blocks"
   [form]
@@ -110,6 +119,7 @@
         (map? form) (reduce-kv (fn [m k v]
                                  (assoc m k (->blocks v))) {} form)
         (keyword? form) (kw->js form)
+        (symbol? form) (name form)
         :else form))
 
 (defn remove-redundant-defaults [defaults props]

--- a/src/org/sparkboard/server/slack/screens.clj
+++ b/src/org/sparkboard/server/slack/screens.clj
@@ -182,10 +182,10 @@
 
 (defn team-broadcast-response
   "User response to broadcast - text field for project status update"
-  [original-msg firebase-key]
+  [original-msg private-metadata]
   [:modal {:title [:plain_text "Project Update"]
            :callback_id "team-broadcast-response"
-           :private_metadata {:broadcast/firebase-key firebase-key}
+           :private_metadata private-metadata
            :submit "Send"}
    [:input {:type "input"
             :label original-msg

--- a/src/org/sparkboard/server/slack/screens.clj
+++ b/src/org/sparkboard/server/slack/screens.clj
@@ -217,7 +217,7 @@
 
 (view/defmodal multi-select-modal
   {}
-  [context payload state]
+  [context state]
   [:modal {:title "Multi-Select examples"}
    [:section
     {:accessory
@@ -263,7 +263,7 @@
 (view/defmodal checks-test
   {:counter 0
    :checks-test #{"value-test-1"}}
-  [context payload state]
+  [context state]
   [:modal {:title "State test"}
    [:actions
     [:button {:action_id "counter+"

--- a/src/org/sparkboard/slack/view.clj
+++ b/src/org/sparkboard/slack/view.clj
@@ -111,8 +111,11 @@
                                     (log/info :updater-receives-values action_id values)
                                     (on-action state (get values action_id)))))) {} on_actions)))
 
+;; formatting
 (defn blockquote [text]
   (str "> " (str/replace text "\n" "\n> ")))
+(defn link [text url]
+  (str "<" url "|" text ">"))
 
 (defmacro defmodal [modal-name initial-state argv body]
   (let [modal-str (str modal-name)

--- a/src/org/sparkboard/slack/view.clj
+++ b/src/org/sparkboard/slack/view.clj
@@ -1,0 +1,136 @@
+(ns org.sparkboard.slack.view
+  (:require [clojure.walk :as walk]
+            [org.sparkboard.js-convert :refer [kw->js]]
+            [org.sparkboard.server.slack.core :as slack]
+            [taoensso.timbre :as log]))
+
+(defn action-value [action]
+  (case (:type action)
+    ("checkboxes"
+      "multi_external_select"
+      "multi_static_select") (->> (:selected_options action)
+                                  (map :value)
+                                  (into #{}))
+    "multi_users_select" (set (:selected_users action))
+    "multi_conversations_select" (set (:selected_conversations action))
+    "multi_channels_select" (set (:selected_channels action))
+    ("static_select"
+      "external_select"
+      "radio_buttons"
+      "overflow") (-> action :selected_option :value)
+    "plain_text_input" (:value action)
+    "users_select" (:selected_user action)
+    "datepicker" (:selected_date action)
+    "button" nil
+    (do
+      (log/warn :not-parsing-action action)
+      action)))
+
+(defn actions-values [actions]
+  (into {} (map (juxt :action_id action-value)) actions))
+
+(defn view-values [view]
+  (->> (apply merge (vals (:values (:state view))))
+       (reduce-kv (fn [m k action]
+                    (assoc m k (action-value action))) {})
+       (merge (:private_metadata view))))
+
+(defn assoc-some [m k v]
+  (if v
+    (assoc m k v)
+    m))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Setting form values on Slack inputs (inconsistent keys + breaks on nil)
+
+(defn- all-options [{:keys [options option-groups]}]
+  (concat options (->> option-groups (mapcat :options))))
+
+(defn assoc-option
+  [m as-key value]
+  (assoc-some m as-key (first (filter #(= (:value %) value) (all-options m)))))
+
+(defn assoc-options
+  [m as-key values]
+  (assoc-some m as-key (seq (filter #(contains? values (:value %)) (all-options m)))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Testing local-state
+
+(defn modal-updater
+  "Returns a handler that will update a modal, given:
+   - modal-fn, accepts [context, payload, state] & returns a [:modal ..] hiccup form
+   - reducer, a function of [state] that returns a new state"
+  [modal-fn on-action]
+  (fn [k context {:keys [view actions] :as payload}]
+    (log/info :actions-values (actions-values actions) actions)
+    (let [prev-state (:private_metadata view)
+          next-state (on-action prev-state (actions-values actions))]
+      (log/info :prev prev-state :next next-state)
+      (slack/views-update (:id view)
+                          (-> (modal-fn context payload next-state)
+                              (assoc-in [1 :private_metadata] next-state))))))
+
+(defn modal-opener
+  "Returns a handler that will open a modal, given:
+   - modal-fn, accepts [context, payload, state] & returnsn a [:modal ..] hiccup form
+   - initial-state, a map"
+  [modal-fn initial-state f]
+  (fn [_ context payload]
+    (-> (modal-fn context payload initial-state)
+        (assoc-in [1 :private_metadata] initial-state)
+        f)))
+
+(defn add-ns [parent action-id]
+  (cond (string? action-id) (str parent ":" action-id)
+        (keyword? action-id) (kw->js action-id)
+        :else (str action-id)))
+
+(defn make-modal* [{:as modal*
+                    :keys [modal-name
+                           modal-str
+                           initial-state
+                           on_actions
+                           on_submit
+                           on_close
+                           modal-fn]}]
+  (merge
+    {(keyword "block_actions" (add-ns modal-str "open")) (modal-opener modal-fn initial-state slack/views-open)
+     (keyword "block_actions" (add-ns modal-str "push")) (modal-opener modal-fn initial-state slack/views-push)}
+    (when on_submit
+      {(keyword "view_submission" modal-str) on_submit})
+    (when on_close
+      {(keyword "view_closed" modal-str) on_close})
+    (reduce-kv (fn [m action_id on-action]
+                 (assoc m
+                   (keyword "block_actions" action_id)
+                   (modal-updater modal-fn
+                                  (fn [state values]
+                                    (log/info :updater-receives-values action_id values)
+                                    (on-action state (get values action_id)))))) {} on_actions)))
+
+(defmacro defmodal [modal-name initial-state argv body]
+  (let [modal-str (str modal-name)
+        found (atom {})
+        consume (fn [x k]
+                  (swap! found assoc k (get x k))
+                  (dissoc x k))
+        add-ns (partial add-ns modal-str)
+        body (walk/postwalk
+               (fn [x]
+                 (if-not (map? x)
+                   x
+                   (cond (:on_action x)
+                         (do (swap! found assoc-in [:on_actions (add-ns (:action_id x))] (:on_action x))
+                             (-> (dissoc x :on_action)
+                                 (update :action_id add-ns)))
+                         (:on_submit x) (consume x :on_submit)
+                         (:on_close x) (consume x :on_close)
+                         (:action_id x) (update x :action_id add-ns)
+                         :else x))) body)]
+    `(def ~modal-name
+       (make-modal* (merge {:modal-name '~(symbol (str *ns*) modal-str)
+                            :modal-str ~modal-str
+                            :modal-fn (fn ~argv ~body)
+                            :initial-state ~initial-state}
+                           ~(deref found))))))


### PR DESCRIPTION
- Put handlers in a map - motivation being, that we can then generate handlers programmatically
- Proof of concept for modals driven by 'local state' stored in `private_metadata`. I think this will many more workflows tractable, eg. buttons that show/hide different elements within a modal, multi-step processes of any kind. The local-state can be modified by simple reducing functions (see `modal-updater`) or by interactive elements that report when their values change. Currently one still has to write all the reducing functions manually but I included a little example of how we could support a `:on-action` key to include these functions inline.

"On my machine" latency is acceptable and I'd guess our staging/prod servers will be even closer to Slack, will have to keep this in mind. 