### PR TITLE
app-redirect with domain

### DIFF
--- a/src/org/sparkboard/server/slack/core.clj
+++ b/src/org/sparkboard/server/slack/core.clj
@@ -85,12 +85,18 @@
 
 (def channel-info
   (memoize
-    (fn [channel-id token]
+    (fn [token channel-id]
       (-> (web-api "conversations.info" {:auth/token token} {:channel channel-id})
           :channel))))
 
-(defn user-info [{:slack/keys [user-id bot-token]}]
-  (-> (web-api "users.info" {:auth/token bot-token} {:user user-id})
+(def team-info
+  (memoize
+    (fn [token team-id]
+      (-> (web-api "team.info" {:auth/token token} {:team team-id})
+          :team))))
+
+(defn user-info [token user-id]
+  (-> (web-api "users.info" {:auth/token token} {:user user-id})
       :user))
 
 ;;;;;;;;;;;;;;;;;;;;;
@@ -132,7 +138,7 @@
             :body
             json/read-value))
 
-  (time (channel-info "C0121SEV6Q2" (-> env/config :slack :bot-user-oauth-token)))
+  (time (channel-info (-> env/config :slack :bot-user-oauth-token) "C0121SEV6Q2"))
 
   )
 

--- a/src/org/sparkboard/server/slack/screens.clj
+++ b/src/org/sparkboard/server/slack/screens.clj
@@ -40,7 +40,7 @@
         (str "Link Account")]])))
 
 (defn admin-menu [context]
-  (when (:is_admin (slack/user-info context))
+  (when (:is_admin (slack/user-info (:slack/bot-token context) (:slack/user-id context)))
     (list
       [:section "🛠 ADMIN ACTIONS\n"]
       [:divider]

--- a/src/org/sparkboard/slack/urls.cljc
+++ b/src/org/sparkboard/slack/urls.cljc
@@ -18,11 +18,9 @@
        "staging" (str "http://" domain ".sparkboard.org")
        "prod" (str "https://" domain)))))
 
-(defn app-redirect [params]
-  (str "https://slack.com/app_redirect?" (uri/map->query-string params)))
-
-(defn slack-home [app-id team-id]
-  (app-redirect {:team team-id :app app-id}))
+(defn app-redirect [{:as params :keys [app team domain]}]
+  {:pre [app team domain]}
+  (str "https://" domain "." "slack.com/app_redirect?" (uri/map->query-string (dissoc params :domain))))
 
 (defn install-slack-app
   "Returns a link that will lead user to install/reinstall app to a workspace"
@@ -58,8 +56,6 @@
 
 (defn link-sparkboard-account
   "Sends the user to Sparkboard to link their account, then redirects them back to Slack"
-  [context]
-  (on-sparkboard context
-                 (slack-home (:slack/app-id context)
-                             (:slack/team-id context))))
+  [{:as context :slack/keys [app-id team-id team-domain]}]
+  (on-sparkboard context (app-redirect {:app app-id :team team-id :domain team-domain})))
 


### PR DESCRIPTION
While [not documented](https://api.slack.com/reference/deep-linking), slack `app_redirect` links work *much better* if they point to the domain for the team instead of just `slack.com`. Otherwise, signed-out users are required to remember and type in the domain for the slack workspace, even though this information is contained in the query parameters. 