### PR TITLE
Refactor Slack server out into its own

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,15 @@ Contents:
 
 ## Develop locally
 
-TODO describe `bb dev` process
-
-1. yarn install
+1. `yarn install`
 1. Start a JVM process with `yarn shadow-cljs`
 1. Open a REPL with your favorite editor, reading the port from `.nrepl-port`
 1. `(shadow/watch :web)` compiles/reloads the client (not much there yet)
 1. `org.sparkboard.server.server/-main` starts the server
+
+Other approacheS:
+  * see *dev/README.md*
+  * `yarn shadow-cljs server` + `yarn shadow-cljs watch web` provides a REPL to `cider-connect` to and also hot reloading
 
 ## Receive Slack events with your local server
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Contents:
 
 ## Develop locally
 
+TODO describe `bb dev` process
+
 1. yarn install
 1. Start a JVM process with `yarn shadow-cljs`
 1. Open a REPL with your favorite editor, reading the port from `.nrepl-port`

--- a/deps.edn
+++ b/deps.edn
@@ -26,7 +26,7 @@
         com.fzakaria/slf4j-timbre {:mvn/version "0.3.19"}
 
         ;; http server
-        ring/ring-jetty-adapter {:mvn/version "1.8.1"}
+        http-kit/http-kit {:mvn/version "2.6.0"}
         ring/ring-defaults {:mvn/version "0.3.2"}
         bidi/bidi {:mvn/version "2.1.6"}
         ring-middleware-format/ring-middleware-format {:mvn/version "0.7.4"}

--- a/deps.edn
+++ b/deps.edn
@@ -18,6 +18,7 @@
         applied-science/js-interop {:mvn/version "0.3.3"}
         clojure.java-time/clojure.java-time {:mvn/version "0.3.3"}
         dev.weavejester/medley {:mvn/version "1.5.0"}
+        clj-gatling/clj-gatling {:mvn/version "0.17.6"}
 
         ;; logging
         com.taoensso/timbre {:mvn/version "4.10.0"}

--- a/dev/org/sparkboard/migration/one_time.clj
+++ b/dev/org/sparkboard/migration/one_time.clj
@@ -1042,12 +1042,15 @@
 (comment
 
  ;; Steps to copy data from prod without processing
- (fetch-mongodb) ;; copies to ~/.db
- (fetch-firebase)  ;; copies to ~/.db
+ (fetch-mongodb) ;; copies to ./.db
+ (fetch-firebase)  ;; copies to ./.db
 
 
  ;; Steps to set up a Datalevin db
  (dl/clear conn) ;; delete all (if exists)
+
+ ;; (on my machine, the next line fails if I don't re-eval `org.sparkboard.datalevin` here)
+ 
  (d/merge-schema! sschema/sb-schema) ;; transact schema
  (do
    ;; transact lookup refs first,

--- a/src/org/sparkboard/client.cljs
+++ b/src/org/sparkboard/client.cljs
@@ -1,10 +1,13 @@
 (ns org.sparkboard.client
   (:require ["react" :as react]
             ["react-dom" :as react-dom]
+            [applied-science.js-interop :as j]
             [org.sparkboard.client.auth :as auth.client]
             [org.sparkboard.client.firebase :as firebase]
             [org.sparkboard.client.routes :refer [routes]]
             [org.sparkboard.client.slack :as slack.client]
+            [re-db.sync :as sync]
+            [re-db.transit]
             [reitit.core :as reitit]
             [reitit.frontend :as rf]
             [reitit.frontend.easy :as rfe]
@@ -14,12 +17,63 @@
 (defonce !current-match (ratom/create nil))
 
 (def router (rf/router routes {}))
+
 (defn path [k & [params]]
   (-> router
       (reitit/match-by-name k params)
       (reitit/match->path)))
 
-(v/defview home [] "Nothing to see here, folks.")
+
+;;; XXX based on sync_values
+(def default-options
+  {:pack re-db.transit/pack
+   :unpack re-db.transit/unpack
+   :path "/ws"})
+
+(defn connect
+  "Connects to websocket server, returns a channel.
+
+     :on-open [socket]
+     :on-message [socket, message]
+     :on-close [socket]
+     "
+  [& {:as options}]
+  (let [{:keys [url port path pack unpack handlers]} (merge default-options options)
+        channel (atom {:!last-message (atom nil)})
+        send (fn [message]
+               (let [^js ws (:ws @channel)]
+                 (when (= 1 (.-readyState ws))
+                   (.send ws (pack message)))))
+        _ (swap! channel assoc :send send)
+        context (assoc options :channel channel)
+        init-ws (fn init-ws []
+                  (let [ws (js/WebSocket. (or url (str "ws://localhost:" port path)))]
+                    (swap! channel assoc :ws ws)
+                    (doto ws
+                      (.addEventListener "open" (fn [_]
+                                                  (sync/on-open channel)))
+                      (.addEventListener "close" (fn [_]
+                                                   (sync/on-close channel)
+                                                   #_(js/setTimeout init-ws 1000)))
+                      (.addEventListener "message" #(let [message (unpack (j/get % :data))]
+                                                      (reset! (:!last-message @channel) message)
+                                                      (sync/handle-message handlers context message))))))]
+    (init-ws)
+    channel))
+
+(def channel
+  (delay (connect {:port 3000
+                   :handlers (sync/watch-handlers)})))
+
+
+(js/console.log "foo")
+
+
+(v/defview home []
+  [:button.p-2.rounded.bg-blue-100
+   {:on-click #(sync/send @channel [:conj!])}
+   "List, grow!"]
+  #_"Nothing to see here, folks.")
 
 (def handlers {:home home
                :slack/invite-offer slack.client/invite-offer

--- a/src/org/sparkboard/datalevin.clj
+++ b/src/org/sparkboard/datalevin.clj
@@ -15,15 +15,20 @@
  (dl/close conn)
  (dl/clear conn)
 
+
+ (->> (d/where [:org/id])
+      (map (d/pull '[*
+                     #_ {:board.settings/default-template [*]}
+                     {:entity/domain [*]}
+                     {:ts/created-by [*]}])))
+
+ 
  (->> (d/where [:board/id])
       (map (d/pull '[(:board/id :db/id true)
                      :board/title
                      {:project/_board [:project/title]}]))
       (drop 3)
       first)
-
-
-
 
 
  )

--- a/src/org/sparkboard/schema.cljc
+++ b/src/org/sparkboard/schema.cljc
@@ -59,7 +59,7 @@
                                              :keyword s/keyword
                                              :http/url s/string
                                              :html/color s/string
-                                             :int s/bigint
+                                             :int s/long #_s/bigint
                                              'inst? s/instant}
                               known-bases (set (keys base-mappings))
                               malli-type (s- m)

--- a/src/org/sparkboard/server.clj
+++ b/src/org/sparkboard/server.clj
@@ -23,7 +23,8 @@
             [ring.util.request]
             [ring.util.response :as ring.response]
             [taoensso.timbre :as log]
-            [tools.sparkboard.transit :as transit]))
+            [tools.sparkboard.transit :as transit])
+  (:import [java.time Instant]))
 
 (comment
   (fire-tokens/decode token))
@@ -34,7 +35,7 @@
      (-> {:body
           (str (html/html-page {:title "Sparkboard"
                                 :styles [{:href "https://unpkg.com/tachyons@4.10.0/css/tachyons.min.css"}]
-                                :scripts/body [{:src (str "/js/compiled/app.js?v=" (.getTime (java.util.Date.)))}]
+                                :scripts/body [{:src (str "/js/compiled/app.js?v=" (.toEpochMilli (Instant/now)))}]
                                 :body [[:script#SPARKBOARD_CONFIG {:type "application/transit+json"}
                                         (raw-string (transit/write config))]
                                        [:div#web]]}))}

--- a/src/org/sparkboard/server.clj
+++ b/src/org/sparkboard/server.clj
@@ -111,7 +111,7 @@
 
 (def app
   (-> (bidi.ring/make-handler ["/" (merge slack.server/routes
-                                          {"ws" (partial default-ws-options handle-ws-request)})])
+                                          {"ws" (partial handle-ws-request default-ws-options)})])
       (ring.middleware.defaults/wrap-defaults ring.middleware.defaults/api-defaults)
       (ring.middleware.format/wrap-restful-format {:formats [:json-kw :transit-json]})
       slack.server/wrap-slack-verify

--- a/src/org/sparkboard/server.clj
+++ b/src/org/sparkboard/server.clj
@@ -145,7 +145,8 @@
       slack.server/wrap-slack-verify
       wrap-static-fallback
       wrap-handle-errors
-      wrap-static-first))
+      wrap-static-first
+      #_wrap-debug-request))
 
 (defonce the-server (atom nil))
 
@@ -180,7 +181,6 @@
 
   ;; DEBUG
   @!list
-
   
   (let [srvr @the-server]
     {:port   (httpkit/server-port @the-server)
@@ -191,5 +191,18 @@
   
   (.shutdown pool)
   (.shutdownNow pool)
+
+  )
+
+(comment ;;;: Intensive request debugging
+  (def !requests (atom []))
+
+  (defn wrap-debug-request [f]
+    (fn [req]
+      (log/info :request req)
+      (swap! !requests conj req)
+      (f req)))
+
+  @!requests
 
   )

--- a/src/org/sparkboard/server.clj
+++ b/src/org/sparkboard/server.clj
@@ -111,6 +111,10 @@
 (comment
   (-main)
 
+  @server
+  
+  (restart-server! 3000)
+  
   (.shutdown pool)
   (.shutdownNow pool)
   )

--- a/src/org/sparkboard/server.clj
+++ b/src/org/sparkboard/server.clj
@@ -2,405 +2,26 @@
   "HTTP server handling Slack requests"
   (:gen-class)
   (:require [bidi.ring :as bidi.ring]
-            [clojure.java.io :as io]
-            [clojure.string :as str]
             [hiccup.util :refer [raw-string]]
-            [lambdaisland.uri :as uri]
             [mhuebert.cljs-static.html :as html]
-            [org.sparkboard.server.nrepl :as nrepl]
             [org.sparkboard.firebase.jvm :as fire-jvm]
             [org.sparkboard.firebase.tokens :as fire-tokens]
             [org.sparkboard.log]
             [org.sparkboard.server.env :as env]
-            [org.sparkboard.slack.db :as slack.db]
-            [org.sparkboard.slack.oauth :as slack-oauth]
-            [org.sparkboard.slack.requests :as slack]
-            [org.sparkboard.slack.screens :as screens]
-            [org.sparkboard.slack.urls :as urls]
+            [org.sparkboard.server.impl :as impl]
+            [org.sparkboard.server.nrepl :as nrepl]
+            [org.sparkboard.slack.server :as slack.server]
             [ring.adapter.jetty :refer [run-jetty]]
             [ring.middleware.defaults]
             [ring.middleware.format]
-            [ring.util.http-response :as ring.http]
             [ring.util.mime-type :as ring.mime-type]
             [ring.util.request]
             [ring.util.response :as ring.response]
             [taoensso.timbre :as log]
-            [tools.sparkboard.js-convert :refer [json->clj]]
-            [tools.sparkboard.slack.api :as slack.api]
-            [tools.sparkboard.slack.view :as v]
-            [tools.sparkboard.transit :as transit])
-  (:import (javax.crypto Mac)
-           (javax.crypto.spec SecretKeySpec)
-           (org.apache.commons.codec.binary Hex)))
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;;; Utility fns
-
-(defn req-auth-token [req]
-  (or (some-> (:headers req) (get "authorization") (str/replace #"^Bearer: " ""))
-      (-> req :params :token)))
-
-(defn return-text [status message]
-  {:status status
-   :headers {"Content-Type" "text/plain"}
-   :body message})
-
-(defmacro spy-args [form]
-  ;;
-  `(do (log/trace :call/forms (quote ~(first form)) ~@(rest form))
-       (let [v# ~form]
-         (log/trace :call/value v#)
-         v#)))
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;;; Individual/second-tier handlers
-
-(defn link-account! [{:keys [slack/team-id
-                             slack/user-id
-                             sparkboard/account-id]}]
-  (let [context (slack.db/slack-context team-id user-id)]
-    ;; TODO
-    ;; visible confirmation step to link the two accounts?
-    (slack.db/link-user-to-account!                         ;; link the accounts
-      {:slack/team-id team-id
-       :slack/user-id user-id
-       :sparkboard/account-id account-id})
-    (v/home! screens/home (assoc context :sparkboard/account-id account-id) user-id)
-    (slack/message-user! context
-      [[:section
-        (str (v/mention (:slack/user-id context)) " "
-             (screens/team-message context :welcome-confirmation))]])
-    (ring.http/found
-      (str "/slack/link-complete?"
-           (uri/map->query-string {:slack (urls/app-redirect {:app (:slack/app-id context)
-                                                              :team team-id
-                                                              :domain (:slack/team-domain context)})
-                                   :sparkboard (-> (slack.db/board-domain (:sparkboard/board-id context))
-                                                   (urls/sparkboard-host))})))))
-
-(defn link-account-for-new-user [context]
-  (if-let [account-id (some-> context :slack/event :user :profile :email fire-jvm/email->uid)]
-    (link-account! (assoc context :sparkboard/account-id account-id))
-    (slack/message-user! context
-      [[:section
-        (str (v/mention (:slack/user-id context))
-             " "
-             (screens/team-message context :welcome))]
-       [:actions
-        [:button {:style "primary"
-                  :url (urls/link-sparkboard-account context)}
-         "Link Sparkboard Account"]]
-       [:context
-        [:plain_text
-         (str "Welcome here! Please click to link your account with Sparkboard, "
-              "where we keep track of all active projects.")]]])))
-
-(defn mock-slack-link-proxy [{{:as token-claims
-                               :keys [slack/user-id
-                                      slack/team-id
-                                      sparkboard/board-id
-                                      sparkboard/account-id
-                                      redirect]} :auth/token-claims
-                              :as req}]
-  (when-not account-id
-    (link-account! (merge (slack.db/slack-context team-id user-id)
-                          token-claims
-                          {:sparkboard/account-id "MOCK_SPARKBOARD_ACCOUNT"})))
-  (if (str/starts-with? redirect "http")
-    (ring.http/found redirect)
-    {:body (str "mock redirect: " redirect)
-     :status 200
-     :headers {"Content-Type" "text/string"}}))
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;;; Middleware
-
-(defn wrap-sparkboard-verify
-  "must be a Sparkboard server request"
-  [f & claims-checks]
-  (fn [req]
-    (let [token (req-auth-token req)
-          claims (some-> token (fire-tokens/decode))
-          check-claims (or (some->> claims-checks seq (apply every-pred)) (constantly true))]
-      (if (check-claims claims)
-        (f (assoc req :auth/token-claims claims))
-        (do
-          (log/warn "Sparkboard token verification failed." {:uri (:uri req)
-                                                             :claims claims
-                                                             :token token})
-          (return-text 401 "Invalid token"))))))
-
-(defn invite-user [req {:keys [slack/team-id
-                               slack/invite-link
-                               slack/team-domain
-                               slack/team-name
-                               sparkboard/account-id
-                               redirect]}]
-  (ring.http/found
-    (str "/slack/invite-offer?"
-         (uri/map->query-string
-           {:custom-token (fire-jvm/custom-token account-id)
-            :team-id team-id
-            :invite-link invite-link
-            :team-domain team-domain
-            :team-name team-name
-            :redirect-encoded (uri/query-encode redirect)}))))
-
-(defn wrap-sparkboard-invite [f]
-  (fn [req]
-    (let [{:as token-claims
-           :sparkboard/keys [account-id board-id]} (:auth/token-claims req)
-          {:as slack-team
-           :slack/keys [team-id invite-link]} (slack.db/board->team board-id)
-          {:as slack-user
-           :keys [slack/user-id]} (slack.db/account->team-user {:slack/team-id team-id
-                                                                :sparkboard/account-id account-id})]
-      (if user-id
-        (f req)
-        (if invite-link
-          (invite-user req (merge slack-team
-                                  slack-user
-                                  token-claims
-                                  (slack.db/team-context team-id)
-                                  {:redirect (str (:uri req) "?" (:query-string req))}))
-          {:status 200
-           :headers {"Content-Type" "text/html"}
-           :body (let [domain (:slack/team-domain (slack.db/team-context team-id))]
-                   (str "You need an invite link to join <a href='https://" domain ".slack.com'>" domain ".slack.com</a>. "
-                        "Please contact an organizer."))})))))
-
-(defn find-or-create-channel [{:sparkboard/keys [board-id
-                                                 account-id
-                                                 project-id
-                                                 project-title]}]
-  (or (slack.db/project->linked-channel project-id)
-      (let [{:keys [slack/team-id slack/team-name]} (slack.db/board->team board-id)
-            {:keys [slack/user-id]} (slack.db/account->team-user {:slack/team-id team-id
-                                                                  :sparkboard/account-id account-id})
-            project-title (v/format-channel-name (str "project-" project-title))]
-        (assert (not (str/blank? project-title)) "Project title is required")
-        ;; possible states:
-        ;; - user is a member of the workspace, but the account is not yet linked
-        ;;   ->
-        ;; - user is not a member of the workspace
-        ;;   -> send them to invite-link
-
-        (if-not user-id
-          {:status 200
-           :body (str "You are not a member of " team-name ".")}
-          (let [{:as context
-                 :slack/keys [bot-token
-                              bot-user-id
-                              user-id]} (slack.db/slack-context team-id user-id)
-                domain (slack.db/board-domain board-id)
-                project-url (str (urls/sparkboard-host domain) "/project/" project-id)
-                channel-id (-> (spy-args (slack.api/request! "conversations.create"
-                                                             {:auth/token bot-token}
-                                                             {:user_ids [bot-user-id] ;; adding user-id here does not work
-                                                         :is_private false
-                                                         :name project-title}))
-                               :channel
-                               :id)]
-            (spy-args (slack.api/request! "conversations.invite"
-                                          {:auth/token bot-token}
-                                          {:channel channel-id
-                                      :users [user-id]}))
-            (spy-args (slack.api/request! "conversations.setTopic"
-                                          {:auth/token bot-token}
-                                          {:channel channel-id
-                                          :topic (v/link "View on Sparkboard" project-url)}))
-            (spy-args (slack.db/link-channel-to-project! {:slack/team-id team-id
-                                                          :slack/channel-id channel-id
-                                                          :sparkboard/project-id project-id}))
-            (assoc context :slack/channel-id channel-id))))))
-
-(defn project-channel-deep-link [{:keys [slack/team-id
-                                         slack/channel-id]}]
-  (urls/app-redirect {:app (-> env/config :slack :app-id)
-                      :domain (:slack/team-domain (slack.db/team-context team-id))
-                      :team team-id
-                      :channel channel-id}))
-
-(defn nav-project-channel [{:as req
-                            {:sparkboard/keys [account-id
-                                               board-id]} :auth/token-claims
-                            {:keys [project-id
-                                    project-title]} :params}]
-  (ring.http/found
-    (-> (find-or-create-channel #:sparkboard{:board-id board-id
-                                             :account-id account-id
-                                             :project-id project-id
-                                             :project-title project-title})
-        (project-channel-deep-link))))
-
-(defn hash-hmac256 [secret message]
-  (-> (Mac/getInstance "HmacSHA256")
-      (doto (.init (SecretKeySpec. (.getBytes secret "UTF-8") "HmacSHA256")))
-      (.doFinal (.getBytes message "UTF-8"))
-      (Hex/encodeHexString)))
-
-(defn peek-body-string
-  "Returns req with :body-string, and replaces :body with a new unread input stream"
-  [req]
-  (let [body-string (slurp (:body req)
-                      :encoding (or (ring.util.request/character-encoding req)
-                                    "UTF-8"))]
-    (assoc req :body (io/input-stream (.getBytes body-string))
-               :body-string body-string)))
-
-(defn wrap-slack-verify
-  "Verifies requests containing `x-slack-signature` header.
-   Must eval before ring formatting middleware (to access body input-stream)"
-  [f]
-  ;; https://api.slack.com/authentication/verifying-requests-from-slack
-  (fn [{:as req :keys [headers]}]
-    (if-let [x-slack-signature (headers "x-slack-signature")]
-      (let [{:as req :keys [body-string]} (peek-body-string req)
-            secret (-> env/config :slack :signing-secret)
-            message (str "v0:" (headers "x-slack-request-timestamp") ":" body-string)
-            hashed (str "v0=" (hash-hmac256 secret message))]
-        (if (= hashed x-slack-signature)
-          (f req)
-          (do
-            (log/warn "Slack verification failed. Possible causes: bad signing secret in env/config, attack.")
-            (ring.http/unauthorized))))
-      (f req))))
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;;; Async processing (mostly parallel Slack HTTP responses)
-
-(defn goetz
-  "Number of threads to have in a thread pool, per Brian Goetz's 'Java Concurrency in Practice' formula'.
-  `wait-time`    = approximate total time (ms) waiting (e.g. on Firebase or Slack requests)
-  `service-time` = approximate time (ms) processing requests"
-  [wait-time service-time]
-  (int (* (.availableProcessors (Runtime/getRuntime))
-          (+ 1 (/ wait-time service-time)))))
-
-(defonce pool
-         (java.util.concurrent.Executors/newFixedThreadPool (goetz 500 10)))
-
-(comment
-  (.submit ^java.util.concurrent.ExecutorService pool
-           ^Callable #(log/info (inc 5))))
-
-;; Declare JVM-wide uncaught exception handler, so exceptions on the
-;; thread pool are logged as errors instead of merely printed.
-;; from https://stuartsierra.com/2015/05/27/clojure-uncaught-exceptions
-(Thread/setDefaultUncaughtExceptionHandler
-  (reify Thread$UncaughtExceptionHandler
-    (uncaughtException [_ thread ex]
-      (log/error (str "Uncaught exception on" (.getName thread)) ex))))
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-(v/register-handlers! {:shortcut/main-menu (partial v/open! screens/shortcut-modal)
-                       :event/app_home_opened (partial v/handle-home-opened! screens/home)
-                       :event/team_join link-account-for-new-user})
-
-(defn missing-handler [{:keys [:slack/handler-id]}]
-  ;; block_action events are sent even for things like buttons with URLs.
-  ;; set an action-id of :no-op for these to avoid seeing a warning/error.
-  (when (not= "no-op" (namespace handler-id))
-    (log/error :unhandled-request handler-id)))
-
-
-(defn parse-slack-params [{:as params :keys [event payload challenge]}]
-  (cond challenge
-        {:slack/challenge challenge}
-        event
-        #:slack{:event event
-                :user-id (if (map? (:user event))           ;; sometimes `user` is an id string, sometimes a map containing the id
-                           (:id (:user event))
-                           (:user event))
-                :team-id (:team_id params)
-                :handler-id (keyword "event" (:type event))}
-
-        payload
-        (let [payload (-> (json->clj payload)
-                          ;; private_metadata is deserialized here, and serialized in `slack.hiccup`
-                          (update-in [:view :private_metadata] #(if (str/blank? %) nil (transit/read %))))]
-          #:slack{:user-id (-> payload :user :id)
-                  :team-id (-> payload :team :id)
-                  :payload payload
-                  :handler-id (case (:type payload)
-                                "shortcut" (keyword "shortcut" (:callback_id payload))
-                                "view_submission" (keyword (-> payload :view :callback_id) "submit")
-                                "view_closed" (keyword (-> payload :view :callback_id) "close")
-                                "block_actions" (keyword (-> payload :actions first :action_id))
-                                (keyword "UNKNOWN_PAYLOAD_TYPE" (:type payload "nil")))})))
-
-(defn handle-slack-req [req]
-  (let [{:as context
-         :slack/keys [challenge team-id user-id handler-id]} (parse-slack-params (:params req))]
-    (log/trace "[slack-req]" req)
-    (log/trace "[slack-context]" handler-id context)
-    (if challenge
-      (ring.http/ok challenge)
-      (let [context (merge context (slack.db/slack-context team-id user-id))
-            handler (@v/registry handler-id missing-handler)
-            exec #(binding [slack.api/*context* context] (handler context))]
-        (if (:response-action? (meta handler))              ;; add ^:response-action? metadata to handlers that may return a response
-          (or (exec) (ring.http/ok))
-          (do (.execute ^java.util.concurrent.ExecutorService pool ^Callable exec)
-              (ring.http/ok)))))))
-
-(def routes
-  ["/" (merge {"slack-api" handle-slack-req
-               "slack-api/oauth-redirect" slack-oauth/redirect
-               "slack/" {"link-account" (wrap-sparkboard-verify (comp link-account! :auth/token-claims)
-                                                                :sparkboard/server-request?)
-                         ["project-channel/" :project-id] (-> nav-project-channel
-                                                              (wrap-sparkboard-invite)
-                                                              (wrap-sparkboard-verify :sparkboard/account-id
-                                                                                      :sparkboard/board-id))
-                         "install" #'slack-oauth/install-redirect
-                         "app-redirect" (fn [{{:as query :keys [team]} :params}]
-                                          (assert team "Slack team not provided")
-                                          (ring.http/found
-                                           (urls/app-redirect
-                                            (assoc query
-                                              :app (-> env/config :slack :app-id)
-                                              :domain (:slack/team-domain (slack.db/team-context team))))))
-                         "reinstall" {"" (fn [req]
-                                           (ring.http/found (urls/install-slack-app {:reinstall? true})))
-                                      ["/" :team-id] (fn [{{:keys [team-id]} :params}]
-                                                       (ring.http/found (urls/install-slack-app {:slack/team-id team-id})))}}}
-              (when (env/config :dev/mock-sparkboard? true)
-                {["mock/" :domain] {"/slack-link" (wrap-sparkboard-verify mock-slack-link-proxy)
-                                    [[#".*" :catchall]]
-                                    (fn [{:keys [params]}] {:body (str "Mock page for " (:domain params) "/" (:catchall params))
-                                                            :status 200
-                                                            :headers {"Content-Type" "text/plain"}})}}))])
+            [tools.sparkboard.transit :as transit]))
 
 (comment
   (fire-tokens/decode token))
-
-(defn wrap-handle-errors [f]
-  (fn [req]
-    (log/info :URI (:uri req))
-    (try (f req)
-         (catch Exception e
-           (if (env/config :dev.logging/tap?)
-             (log/error (ex-message e) e)
-             (log/error (ex-message e)
-                        (ex-data e)
-                        (ex-cause e)))
-           (return-text
-             (:status (ex-data e) 500)
-             (ex-message e)))
-         (catch java.lang.AssertionError e
-           (if (env/config :dev.logging/tap?)
-             (log/error (ex-message e) e)
-             (log/error (ex-message e)
-                        (ex-data e)
-                        (ex-cause e)))
-           (return-text
-             (:status (ex-data e) 500)
-             (ex-message e))))))
-
-(defn public-resource [path]
-  (some-> (ring.response/resource-response path {:root "public"})
-          (ring.response/content-type (ring.mime-type/ext-mime-type path))))
 
 (def spa-page
   (memoize
@@ -414,6 +35,33 @@
                                         [:div#web]]}))}
           (ring.response/content-type "text/html")
           (ring.response/status 200)))))
+
+(defn wrap-handle-errors [f]
+  (fn [req]
+    (log/info :URI (:uri req))
+    (try (f req)
+         (catch Exception e
+           (if (env/config :dev.logging/tap?)
+             (log/error (ex-message e) e)
+             (log/error (ex-message e)
+                        (ex-data e)
+                        (ex-cause e)))
+           (impl/return-text
+            (:status (ex-data e) 500)
+            (ex-message e)))
+         (catch java.lang.AssertionError e
+           (if (env/config :dev.logging/tap?)
+             (log/error (ex-message e) e)
+             (log/error (ex-message e)
+                        (ex-data e)
+                        (ex-cause e)))
+           (impl/return-text
+            (:status (ex-data e) 500)
+            (ex-message e))))))
+
+(defn public-resource [path]
+  (some-> (ring.response/resource-response path {:root "public"})
+          (ring.response/content-type (ring.mime-type/ext-mime-type path))))
 
 (defn wrap-static-first [f]
   ;; serve static files before all the other middleware, logging, etc.
@@ -429,10 +77,10 @@
           (spa-page env/client-config)))))
 
 (def app
-  (-> (bidi.ring/make-handler routes)
+  (-> (bidi.ring/make-handler ["/" slack.server/routes])
       (ring.middleware.defaults/wrap-defaults ring.middleware.defaults/api-defaults)
       (ring.middleware.format/wrap-restful-format {:formats [:json-kw :transit-json]})
-      wrap-slack-verify
+      slack.server/wrap-slack-verify
       wrap-static-fallback
       wrap-handle-errors
       wrap-static-first))

--- a/src/org/sparkboard/server/impl.clj
+++ b/src/org/sparkboard/server/impl.clj
@@ -1,0 +1,27 @@
+(ns org.sparkboard.server.impl)
+
+(defn req-auth-token [req]
+  (or (some-> (:headers req) (get "authorization") (str/replace #"^Bearer: " ""))
+      (-> req :params :token)))
+
+(defn return-text [status message]
+  {:status status
+   :headers {"Content-Type" "text/plain"}
+   :body message})
+
+(defn wrap-sparkboard-verify
+  "must be a Sparkboard server request"
+  [f & claims-checks]
+  (fn [req]
+    (let [token (req-auth-token req)
+          claims (some-> token (fire-tokens/decode))
+          check-claims (or (some->> claims-checks seq (apply every-pred)) (constantly true))]
+      (if (check-claims claims)
+        (f (assoc req :auth/token-claims claims))
+        (do
+          (log/warn "Sparkboard token verification failed." {:uri (:uri req)
+                                                             :claims claims
+                                                             :token token})
+          (return-text 401 "Invalid token"))))))
+
+

--- a/src/org/sparkboard/server/impl.clj
+++ b/src/org/sparkboard/server/impl.clj
@@ -1,4 +1,7 @@
-(ns org.sparkboard.server.impl)
+(ns org.sparkboard.server.impl
+  (:require [clojure.string :as str]
+            [org.sparkboard.firebase.tokens :as fire-tokens]
+            [taoensso.timbre :as log]))
 
 (defn req-auth-token [req]
   (or (some-> (:headers req) (get "authorization") (str/replace #"^Bearer: " ""))

--- a/src/org/sparkboard/slack/screens.clj
+++ b/src/org/sparkboard/slack/screens.clj
@@ -317,7 +317,7 @@
                   (examples/dev-overflow context))
      :fields [[:md
                (str "_Updated: "
-                    (->> (java.util.Date.)
+                    (->> (java.util.Date.) ;; TODO java.time
                          (.format (new java.text.SimpleDateFormat "h:mm:ss a, MMMM d")))
                     "_")]
               [:md (str (:slack/app-id context) "." (:slack/team-id context))]]}]))

--- a/src/org/sparkboard/slack/server.clj
+++ b/src/org/sparkboard/slack/server.clj
@@ -1,4 +1,5 @@
 (ns org.sparkboard.slack.server
+  "HTTP routes for Slack integration"
   (:require
    [clojure.string :as str]
    [clojure.java.io :as io]

--- a/src/org/sparkboard/slack/server.clj
+++ b/src/org/sparkboard/slack/server.clj
@@ -1,0 +1,349 @@
+(ns org.sparkboard.slack.server
+  (:require
+   [clojure.string :as str]
+   [lambdaisland.uri :as uri]
+   [org.sparkboard.server.env :as env]
+   [org.sparkboard.server.impl :refer [wrap-sparkboard-verify]]
+   [org.sparkboard.slack.db :as slack.db]
+   [org.sparkboard.slack.oauth :as slack-oauth]
+   [org.sparkboard.slack.requests :as slack]
+   [org.sparkboard.slack.screens :as screens]
+   [org.sparkboard.slack.urls :as urls]
+   [ring.util.http-response :as ring.http]
+   [taoensso.timbre :as log]
+   [tools.sparkboard.js-convert :refer [json->clj]]
+   [tools.sparkboard.slack.view :as v])
+  (:import (javax.crypto Mac)
+           (javax.crypto.spec SecretKeySpec)
+           (org.apache.commons.codec.binary Hex)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;; Individual/second-tier handlers
+
+(defn link-account! [{:keys [slack/team-id
+                             slack/user-id
+                             sparkboard/account-id]}]
+  (let [context (slack.db/slack-context team-id user-id)]
+    ;; TODO
+    ;; visible confirmation step to link the two accounts?
+    (slack.db/link-user-to-account!                         ;; link the accounts
+     {:slack/team-id team-id
+      :slack/user-id user-id
+      :sparkboard/account-id account-id})
+    (v/home! screens/home (assoc context :sparkboard/account-id account-id) user-id)
+    (slack/message-user! context
+                         [[:section
+                           (str (v/mention (:slack/user-id context)) " "
+                                (screens/team-message context :welcome-confirmation))]])
+    (ring.http/found
+     (str "/slack/link-complete?"
+          (uri/map->query-string {:slack (urls/app-redirect {:app (:slack/app-id context)
+                                                             :team team-id
+                                                             :domain (:slack/team-domain context)})
+                                  :sparkboard (-> (slack.db/board-domain (:sparkboard/board-id context))
+                                                  (urls/sparkboard-host))})))))
+
+(defn link-account-for-new-user [context]
+  (if-let [account-id (some-> context :slack/event :user :profile :email fire-jvm/email->uid)]
+    (link-account! (assoc context :sparkboard/account-id account-id))
+    (slack/message-user! context
+                         [[:section
+                           (str (v/mention (:slack/user-id context))
+                                " "
+                                (screens/team-message context :welcome))]
+                          [:actions
+                           [:button {:style "primary"
+                                     :url (urls/link-sparkboard-account context)}
+                            "Link Sparkboard Account"]]
+                          [:context
+                           [:plain_text
+                            (str "Welcome here! Please click to link your account with Sparkboard, "
+                                 "where we keep track of all active projects.")]]])))
+
+(defn mock-slack-link-proxy [{{:as token-claims
+                               :keys [slack/user-id
+                                      slack/team-id
+                                      sparkboard/board-id
+                                      sparkboard/account-id
+                                      redirect]} :auth/token-claims
+                              :as req}]
+  (when-not account-id
+    (link-account! (merge (slack.db/slack-context team-id user-id)
+                          token-claims
+                          {:sparkboard/account-id "MOCK_SPARKBOARD_ACCOUNT"})))
+  (if (str/starts-with? redirect "http")
+    (ring.http/found redirect)
+    {:body (str "mock redirect: " redirect)
+     :status 200
+     :headers {"Content-Type" "text/string"}}))
+
+(v/register-handlers! {:shortcut/main-menu (partial v/open! screens/shortcut-modal)
+                       :event/app_home_opened (partial v/handle-home-opened! screens/home)
+                       :event/team_join link-account-for-new-user})
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;; Utility fns
+
+(defn req-auth-token [req]
+  (or (some-> (:headers req) (get "authorization") (str/replace #"^Bearer: " ""))
+      (-> req :params :token)))
+
+(defn return-text [status message]
+  {:status status
+   :headers {"Content-Type" "text/plain"}
+   :body message})
+
+(defmacro spy-args [form]
+  ;;
+  `(do (log/trace :call/forms (quote ~(first form)) ~@(rest form))
+       (let [v# ~form]
+         (log/trace :call/value v#)
+         v#)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;; Middleware
+
+(defn invite-user [req {:keys [slack/team-id
+                               slack/invite-link
+                               slack/team-domain
+                               slack/team-name
+                               sparkboard/account-id
+                               redirect]}]
+  (ring.http/found
+   (str "/slack/invite-offer?"
+        (uri/map->query-string
+         {:custom-token (fire-jvm/custom-token account-id)
+          :team-id team-id
+          :invite-link invite-link
+          :team-domain team-domain
+          :team-name team-name
+          :redirect-encoded (uri/query-encode redirect)}))))
+
+(defn wrap-sparkboard-invite [f]
+  (fn [req]
+    (let [{:as token-claims
+           :sparkboard/keys [account-id board-id]} (:auth/token-claims req)
+          {:as slack-team
+           :slack/keys [team-id invite-link]} (slack.db/board->team board-id)
+          {:as slack-user
+           :keys [slack/user-id]} (slack.db/account->team-user {:slack/team-id team-id
+                                                                :sparkboard/account-id account-id})]
+      (if user-id
+        (f req)
+        (if invite-link
+          (invite-user req (merge slack-team
+                                  slack-user
+                                  token-claims
+                                  (slack.db/team-context team-id)
+                                  {:redirect (str (:uri req) "?" (:query-string req))}))
+          {:status 200
+           :headers {"Content-Type" "text/html"}
+           :body (let [domain (:slack/team-domain (slack.db/team-context team-id))]
+                   (str "You need an invite link to join <a href='https://" domain ".slack.com'>" domain ".slack.com</a>. "
+                        "Please contact an organizer."))})))))
+
+(defn find-or-create-channel [{:sparkboard/keys [board-id
+                                                 account-id
+                                                 project-id
+                                                 project-title]}]
+  (or (slack.db/project->linked-channel project-id)
+      (let [{:keys [slack/team-id slack/team-name]} (slack.db/board->team board-id)
+            {:keys [slack/user-id]} (slack.db/account->team-user {:slack/team-id team-id
+                                                                  :sparkboard/account-id account-id})
+            project-title (v/format-channel-name (str "project-" project-title))]
+        (assert (not (str/blank? project-title)) "Project title is required")
+        ;; possible states:
+        ;; - user is a member of the workspace, but the account is not yet linked
+        ;;   ->
+        ;; - user is not a member of the workspace
+        ;;   -> send them to invite-link
+
+        (if-not user-id
+          {:status 200
+           :body (str "You are not a member of " team-name ".")}
+          (let [{:as context
+                 :slack/keys [bot-token
+                              bot-user-id
+                              user-id]} (slack.db/slack-context team-id user-id)
+                domain (slack.db/board-domain board-id)
+                project-url (str (urls/sparkboard-host domain) "/project/" project-id)
+                channel-id (-> (spy-args (slack.api/request! "conversations.create"
+                                                             {:auth/token bot-token}
+                                                             {:user_ids [bot-user-id] ;; adding user-id here does not work
+                                                              :is_private false
+                                                              :name project-title}))
+                               :channel
+                               :id)]
+            (spy-args (slack.api/request! "conversations.invite"
+                                          {:auth/token bot-token}
+                                          {:channel channel-id
+                                           :users [user-id]}))
+            (spy-args (slack.api/request! "conversations.setTopic"
+                                          {:auth/token bot-token}
+                                          {:channel channel-id
+                                           :topic (v/link "View on Sparkboard" project-url)}))
+            (spy-args (slack.db/link-channel-to-project! {:slack/team-id team-id
+                                                          :slack/channel-id channel-id
+                                                          :sparkboard/project-id project-id}))
+            (assoc context :slack/channel-id channel-id))))))
+
+(defn project-channel-deep-link [{:keys [slack/team-id
+                                         slack/channel-id]}]
+  (urls/app-redirect {:app (-> env/config :slack :app-id)
+                      :domain (:slack/team-domain (slack.db/team-context team-id))
+                      :team team-id
+                      :channel channel-id}))
+
+(defn nav-project-channel [{:as req
+                            {:sparkboard/keys [account-id
+                                               board-id]} :auth/token-claims
+                            {:keys [project-id
+                                    project-title]} :params}]
+  (ring.http/found
+   (-> (find-or-create-channel #:sparkboard{:board-id board-id
+                                            :account-id account-id
+                                            :project-id project-id
+                                            :project-title project-title})
+       (project-channel-deep-link))))
+
+(defn hash-hmac256 [secret message]
+  (-> (Mac/getInstance "HmacSHA256")
+      (doto (.init (SecretKeySpec. (.getBytes secret "UTF-8") "HmacSHA256")))
+      (.doFinal (.getBytes message "UTF-8"))
+      (Hex/encodeHexString)))
+
+(defn peek-body-string
+  "Returns req with :body-string, and replaces :body with a new unread input stream"
+  [req]
+  (let [body-string (slurp (:body req)
+                           :encoding (or (ring.util.request/character-encoding req)
+                                         "UTF-8"))]
+    (assoc req :body (io/input-stream (.getBytes body-string))
+               :body-string body-string)))
+
+(defn wrap-slack-verify
+  "Verifies requests containing `x-slack-signature` header.
+   Must eval before ring formatting middleware (to access body input-stream)"
+  [f]
+  ;; https://api.slack.com/authentication/verifying-requests-from-slack
+  (fn [{:as req :keys [headers]}]
+    (if-let [x-slack-signature (headers "x-slack-signature")]
+      (let [{:as req :keys [body-string]} (peek-body-string req)
+            secret (-> env/config :slack :signing-secret)
+            message (str "v0:" (headers "x-slack-request-timestamp") ":" body-string)
+            hashed (str "v0=" (hash-hmac256 secret message))]
+        (if (= hashed x-slack-signature)
+          (f req)
+          (do
+            (log/warn "Slack verification failed. Possible causes: bad signing secret in env/config, attack.")
+            (ring.http/unauthorized))))
+      (f req))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defn missing-handler [{:keys [:slack/handler-id]}]
+  ;; block_action events are sent even for things like buttons with URLs.
+  ;; set an action-id of :no-op for these to avoid seeing a warning/error.
+  (when (not= "no-op" (namespace handler-id))
+    (log/error :unhandled-request handler-id)))
+
+
+(defn parse-slack-params [{:as params :keys [event payload challenge]}]
+  (cond challenge
+        {:slack/challenge challenge}
+        event
+        #:slack{:event event
+                :user-id (if (map? (:user event))           ;; sometimes `user` is an id string, sometimes a map containing the id
+                           (:id (:user event))
+                           (:user event))
+                :team-id (:team_id params)
+                :handler-id (keyword "event" (:type event))}
+
+        payload
+        (let [payload (-> (json->clj payload)
+                          ;; private_metadata is deserialized here, and serialized in `slack.hiccup`
+                          (update-in [:view :private_metadata] #(if (str/blank? %) nil (transit/read %))))]
+          #:slack{:user-id (-> payload :user :id)
+                  :team-id (-> payload :team :id)
+                  :payload payload
+                  :handler-id (case (:type payload)
+                                "shortcut" (keyword "shortcut" (:callback_id payload))
+                                "view_submission" (keyword (-> payload :view :callback_id) "submit")
+                                "view_closed" (keyword (-> payload :view :callback_id) "close")
+                                "block_actions" (keyword (-> payload :actions first :action_id))
+                                (keyword "UNKNOWN_PAYLOAD_TYPE" (:type payload "nil")))})))
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;; Async processing (mostly parallel Slack HTTP responses)
+
+(defn goetz
+  "Number of threads to have in a thread pool, per Brian Goetz's 'Java Concurrency in Practice' formula'.
+  `wait-time`    = approximate total time (ms) waiting (e.g. on Firebase or Slack requests)
+  `service-time` = approximate time (ms) processing requests"
+  [wait-time service-time]
+  (int (* (.availableProcessors (Runtime/getRuntime))
+          (+ 1 (/ wait-time service-time)))))
+
+(defonce pool
+  (java.util.concurrent.Executors/newFixedThreadPool (goetz 500 10)))
+
+(comment
+ (.submit ^java.util.concurrent.ExecutorService pool
+          ^Callable #(log/info (inc 5))))
+
+;; Declare JVM-wide uncaught exception handler, so exceptions on the
+;; thread pool are logged as errors instead of merely printed.
+;; from https://stuartsierra.com/2015/05/27/clojure-uncaught-exceptions
+(Thread/setDefaultUncaughtExceptionHandler
+ (reify Thread$UncaughtExceptionHandler
+   (uncaughtException [_ thread ex]
+     (log/error (str "Uncaught exception on" (.getName thread)) ex))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;
+
+
+
+
+(defn handle-slack-req [req]
+  (let [{:as context
+         :slack/keys [challenge team-id user-id handler-id]} (parse-slack-params (:params req))]
+    (log/trace "[slack-req]" req)
+    (log/trace "[slack-context]" handler-id context)
+    (if challenge
+      (ring.http/ok challenge)
+      (let [context (merge context (slack.db/slack-context team-id user-id))
+            handler (@v/registry handler-id missing-handler)
+            exec #(binding [slack.api/*context* context] (handler context))]
+        (if (:response-action? (meta handler))              ;; add ^:response-action? metadata to handlers that may return a response
+          (or (exec) (ring.http/ok))
+          (do (.execute ^java.util.concurrent.ExecutorService pool ^Callable exec)
+              (ring.http/ok)))))))
+
+(def routes
+  (merge {"slack-api" handle-slack-req
+          "slack-api/oauth-redirect" slack-oauth/redirect
+          "slack/" {"link-account" (wrap-sparkboard-verify (comp link-account! :auth/token-claims)
+                                                           :sparkboard/server-request?)
+                    ["project-channel/" :project-id] (-> nav-project-channel
+                                                         (wrap-sparkboard-invite)
+                                                         (wrap-sparkboard-verify :sparkboard/account-id
+                                                                                 :sparkboard/board-id))
+                    "install" #'slack-oauth/install-redirect
+                    "app-redirect" (fn [{{:as query :keys [team]} :params}]
+                                     (assert team "Slack team not provided")
+                                     (ring.http/found
+                                      (urls/app-redirect
+                                       (assoc query
+                                         :app (-> env/config :slack :app-id)
+                                         :domain (:slack/team-domain (slack.db/team-context team))))))
+                    "reinstall" {"" (fn [req]
+                                      (ring.http/found (urls/install-slack-app {:reinstall? true})))
+                                 ["/" :team-id] (fn [{{:keys [team-id]} :params}]
+                                                  (ring.http/found (urls/install-slack-app {:slack/team-id team-id})))}}}
+         (when (env/config :dev/mock-sparkboard? true)
+           {["mock/" :domain] {"/slack-link" (wrap-sparkboard-verify mock-slack-link-proxy)
+                               [[#".*" :catchall]]
+                               (fn [{:keys [params]}] {:body (str "Mock page for " (:domain params) "/" (:catchall params))
+                                                       :status 200
+                                                       :headers {"Content-Type" "text/plain"}})}})))

--- a/src/org/sparkboard/slack/server.clj
+++ b/src/org/sparkboard/slack/server.clj
@@ -1,7 +1,10 @@
 (ns org.sparkboard.slack.server
   (:require
    [clojure.string :as str]
+   [clojure.java.io :as io]
+   [cognitect.transit :as transit]
    [lambdaisland.uri :as uri]
+   [org.sparkboard.firebase.jvm :as fire-jvm]
    [org.sparkboard.server.env :as env]
    [org.sparkboard.server.impl :refer [wrap-sparkboard-verify]]
    [org.sparkboard.slack.db :as slack.db]
@@ -12,6 +15,7 @@
    [ring.util.http-response :as ring.http]
    [taoensso.timbre :as log]
    [tools.sparkboard.js-convert :refer [json->clj]]
+   [tools.sparkboard.slack.api :as slack.api]
    [tools.sparkboard.slack.view :as v])
   (:import (javax.crypto Mac)
            (javax.crypto.spec SecretKeySpec)


### PR DESCRIPTION
Factors Slack code into its own namespaces.

 * Note schema type change from `s/bigint` to `s/long`, because the former breaks the 1-time migration on my machine. See https://github.com/sparkboard/sparkboard/compare/main...slack-server-refactor#diff-82f32cb7aa4eeb8d0fb3dc2aa3b3b8c47863fb0894755b7a57b2d3950d46c85dR62. Worth discussing.
 * switched to http-kit to provide websockets