### PR TITLE
syntax for sync-compatible reactions

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -4,7 +4,7 @@
         ;; v2
         datalevin/datalevin {:mvn/version "0.7.7"}
         io.github.mhuebert/re-db {#_#_:local/root "../re-db"
-                                  :git/sha "b17d5f4962a494366b442e373d649b0336d4ffc5"}
+                                  :git/sha "03a1281a1b38707ec42361f117c6ca1d7610ddea"}
         io.github.mhuebert/yawn {#_#_:local/root "../yawn"
                                  :git/sha "55daa1023d1c4ce147bb459fe8b7906f72d3eab4"}
 

--- a/deps.edn
+++ b/deps.edn
@@ -4,7 +4,7 @@
         ;; v2
         datalevin/datalevin {:mvn/version "0.7.7"}
         io.github.mhuebert/re-db {#_#_:local/root "../re-db"
-                                  :git/sha "03a1281a1b38707ec42361f117c6ca1d7610ddea"}
+                                  :git/sha "739ecfe10cdb9a72aa4f167a9a1cc4ecaa711dc4"}
         io.github.mhuebert/yawn {#_#_:local/root "../yawn"
                                  :git/sha "55daa1023d1c4ce147bb459fe8b7906f72d3eab4"}
 

--- a/deps.edn
+++ b/deps.edn
@@ -4,7 +4,7 @@
         ;; v2
         datalevin/datalevin {:mvn/version "0.7.7"}
         io.github.mhuebert/re-db {#_#_:local/root "../re-db"
-                                  :git/sha "742acafd6d62e1d2f5c2fe5e36c168d8ccf9f6f0"}
+                                  :git/sha "b17d5f4962a494366b442e373d649b0336d4ffc5"}
         io.github.mhuebert/yawn {#_#_:local/root "../yawn"
                                  :git/sha "55daa1023d1c4ce147bb459fe8b7906f72d3eab4"}
 

--- a/src/org/sparkboard/server/queries.clj
+++ b/src/org/sparkboard/server/queries.clj
@@ -11,54 +11,61 @@
        (read/handle-report! conn)))
 
 (defn-memo $org:index [_]
-  (sync/reaction
-   (->> (db/where [:org/id])
-        (mapv (re-db.api/pull '[*])))))
+  (r/reaction
+   (sync/try-value
+    (->> (db/where [:org/id])
+         (mapv (re-db.api/pull '[*]))))))
 
 (defn-memo $org:one [{:keys [org/id]}]
-  (sync/reaction
-   (db/pull '[:org/title
-              {:board/_org [:ts/created-at
-                            :board/id
-                            :board/title]}
-              {:entity/domain [:domain/name]}]
-            [:org/id id])))
+  (r/reaction
+   (sync/try-value
+    (db/pull '[:org/title
+               {:board/_org [:ts/created-at
+                             :board/id
+                             :board/title]}
+               {:entity/domain [:domain/name]}]
+             [:org/id id]))))
 
 (defn-memo $board:index [_route-params]
-  (sync/reaction
-   (->> (db/where [:board/id])
-        (mapv (re-db.api/pull '[:board/title])))))
+  (r/reaction
+   (sync/try-value
+    (->> (db/where [:board/id])
+         (mapv (re-db.api/pull '[:board/title]))))))
 
 (defn-memo $board:one [{:keys [board/id] :as _route-params}]
-  (sync/reaction
-   (db/pull '[*
-              :board/title
-              :board.registration/open?
-              :board/title
-              {:project/_board [*]}
-              {:board/org [:org/title :org/id]}
-              {:member/_board [*]}
-              {:entity/domain [:domain/name]}]
-            [:board/id id])))
+  (r/reaction
+   (sync/try-value
+    (db/pull '[*
+               :board/title
+               :board.registration/open?
+               :board/title
+               {:project/_board [*]}
+               {:board/org [:org/title :org/id]}
+               {:member/_board [*]}
+               {:entity/domain [:domain/name]}]
+             [:board/id id]))))
 
 (defn-memo $project:index [_route-params]
   ;; TODO
   ;; pagination
   ;; search queries
-  (sync/reaction
-   (->> (db/where [:project/id])
-        (take 20)
-        (mapv (re-db.api/pull '[:project/title])))))
+  (r/reaction
+   (sync/try-value
+    (->> (db/where [:project/id])
+         (take 20)
+         (mapv (re-db.api/pull '[:project/title]))))))
 
 (defn-memo $project:one [{:keys [project/id]}]
-  (sync/reaction
-   (db/pull '[*] [:project/id id])))
+  (r/reaction
+   (sync/try-value
+    (db/pull '[*] [:project/id id]))))
 
 (defn-memo $member:one [{:keys [member/id]}]
-  (sync/reaction
-   (db/pull '[*
-              {:member/tags [*]}]
-            [:member/id id])))
+  (r/reaction
+   (sync/try-value
+    (db/pull '[*
+               {:member/tags [*]}]
+             [:member/id id]))))
 
 (defonce !list (atom ()))
 

--- a/src/org/sparkboard/server/queries.clj
+++ b/src/org/sparkboard/server/queries.clj
@@ -11,12 +11,12 @@
        (read/handle-report! conn)))
 
 (defn-memo $org:index [_]
-  (r/reaction
+  (sync/reaction
    (->> (db/where [:org/id])
         (mapv (re-db.api/pull '[*])))))
 
 (defn-memo $org:one [{:keys [org/id]}]
-  (r/reaction
+  (sync/reaction
    (db/pull '[:org/title
               {:board/_org [:ts/created-at
                             :board/id
@@ -25,12 +25,12 @@
             [:org/id id])))
 
 (defn-memo $board:index [_route-params]
-  (r/reaction
+  (sync/reaction
    (->> (db/where [:board/id])
         (mapv (re-db.api/pull '[:board/title])))))
 
 (defn-memo $board:one [{:keys [board/id] :as _route-params}]
-  (r/reaction
+  (sync/reaction
    (db/pull '[*
               :board/title
               :board.registration/open?
@@ -45,17 +45,17 @@
   ;; TODO
   ;; pagination
   ;; search queries
-  (r/reaction
+  (sync/reaction
    (->> (db/where [:project/id])
         (take 20)
         (mapv (re-db.api/pull '[:project/title])))))
 
 (defn-memo $project:one [{:keys [project/id]}]
-  (r/reaction
+  (sync/reaction
    (db/pull '[*] [:project/id id])))
 
 (defn-memo $member:one [{:keys [member/id]}]
-  (r/reaction
+  (sync/reaction
    (db/pull '[*
               {:member/tags [*]}]
             [:member/id id])))

--- a/src/org/sparkboard/server/queries.clj
+++ b/src/org/sparkboard/server/queries.clj
@@ -1,9 +1,8 @@
 (ns org.sparkboard.server.queries
   (:require [re-db.reactive :as r]
-            [re-db.query :as q]
             [re-db.read :as read]
             [re-db.sync :as sync]
-            [re-db.memo :refer [def-memo defn-memo]]
+            [re-db.memo :refer [defn-memo]]
             [org.sparkboard.datalevin :refer [conn]]
             [re-db.api :as db]))
 
@@ -12,54 +11,54 @@
        (read/handle-report! conn)))
 
 (defn-memo $org:index [_]
-  (q/reaction conn
-    (->> (db/where [:org/id])
-         (mapv (re-db.api/pull '[*])))))
+  (r/reaction
+   (->> (db/where [:org/id])
+        (mapv (re-db.api/pull '[*])))))
 
 (defn-memo $org:one [{:keys [org/id]}]
-  (q/reaction conn
-    (db/pull '[:org/title
-               {:board/_org [:ts/created-at
-                             :board/id
-                             :board/title]}
-               {:entity/domain [:domain/name]}]
-             [:org/id id])))
+  (r/reaction
+   (db/pull '[:org/title
+              {:board/_org [:ts/created-at
+                            :board/id
+                            :board/title]}
+              {:entity/domain [:domain/name]}]
+            [:org/id id])))
 
 (defn-memo $board:index [_route-params]
-  (q/reaction conn
-    (->> (db/where [:board/id])
-         (mapv (re-db.api/pull '[:board/title])))))
+  (r/reaction
+   (->> (db/where [:board/id])
+        (mapv (re-db.api/pull '[:board/title])))))
 
 (defn-memo $board:one [{:keys [board/id] :as _route-params}]
-  (q/reaction conn
-              (db/pull '[*
-                         :board/title
-                         :board.registration/open?
-                         :board/title
-                         {:project/_board [*]}
-                         {:board/org [:org/title :org/id]}
-                         {:member/_board [*]}
-                         {:entity/domain [:domain/name]}]
-                       [:board/id id])))
+  (r/reaction
+   (db/pull '[*
+              :board/title
+              :board.registration/open?
+              :board/title
+              {:project/_board [*]}
+              {:board/org [:org/title :org/id]}
+              {:member/_board [*]}
+              {:entity/domain [:domain/name]}]
+            [:board/id id])))
 
 (defn-memo $project:index [_route-params]
   ;; TODO
   ;; pagination
   ;; search queries
-  (q/reaction conn
-    (->> (db/where [:project/id])
-         (take 20)
-         (mapv (re-db.api/pull '[:project/title])))))
+  (r/reaction
+   (->> (db/where [:project/id])
+        (take 20)
+        (mapv (re-db.api/pull '[:project/title])))))
 
 (defn-memo $project:one [{:keys [project/id]}]
-  (q/reaction conn
-    (db/pull '[*] [:project/id id])))
+  (r/reaction
+   (db/pull '[*] [:project/id id])))
 
 (defn-memo $member:one [{:keys [member/id]}]
-  (q/reaction conn
-    (db/pull '[*
-               {:member/tags [*]}]
-             [:member/id id])))
+  (r/reaction
+   (db/pull '[*
+              {:member/tags [*]}]
+            [:member/id id])))
 
 (defonce !list (atom ()))
 


### PR DESCRIPTION
`re-db.query/reaction` was doing two things:

1. Wrapping the reaction in try/catch, returning a map containing `:value` or `:error`
2. Binding `re-db.read/*conn*` inside the reaction

For (1) I added a `try-value` macro to `re-db.sync`

Since (2) is primarily about testing (or a case where an app uses multiple db's) I renamed it to `bound-reaction` and no longer use it in our app code.

I added `re-db.sync/reaction` which would combine `reaction` and `try-value` but this felt confusing because we would still want to use "ordinary" reactions within queries, the try-value is only necessary at the top level.

So, undecided how this should go.

Maybe we are actually missing an error-handling piece in `re-db.reaction`, treating reaction errors as a first-class thing and allowing them to propagate upwards.
