### PR TITLE
re-db version - some redef stuff fixed, mutation views

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_6" project-jdk-name="openjdk-15" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_6" project-jdk-name="openjdk-19" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/classes" />
   </component>
 </project>

--- a/deps.edn
+++ b/deps.edn
@@ -4,10 +4,10 @@
         ;; v2
         datalevin/datalevin {:mvn/version "0.8.4"}
         io.github.mhuebert/re-db {#_#_:local/root "../re-db"
-                                  :git/sha "b5e772313f09f2f5fc55d3ad2cce7d5047789fa5"}
+                                  :git/sha "6aa5573f152dbde7a5d8f5e82d18c729e053ae55"}
         io.github.mhuebert/yawn {#_#_:local/root "../yawn"
-                                 :git/sha "b8cc0e21d455632e5a6b1d7d0de56a221e73b0c5"}
-        io.github.mhuebert/inside-out {:local/root "../inside-out"}
+                                 :git/sha "ec725be4808dd08f60ec8770a02f19df5ae3af43"}
+        #_#_io.github.mhuebert/inside-out {:local/root "../inside-out"}
         ;; Google Cloud
         com.google.firebase/firebase-admin {:mvn/version "6.13.0"}
 

--- a/deps.edn
+++ b/deps.edn
@@ -4,10 +4,10 @@
         ;; v2
         datalevin/datalevin {:mvn/version "0.8.4"}
         io.github.mhuebert/re-db {#_#_:local/root "../re-db"
-                                  :git/sha "e4d5f5c01b208d54e73e8f417be33921fb054774"}
+                                  :git/sha "b5e772313f09f2f5fc55d3ad2cce7d5047789fa5"}
         io.github.mhuebert/yawn {#_#_:local/root "../yawn"
                                  :git/sha "b8cc0e21d455632e5a6b1d7d0de56a221e73b0c5"}
-
+        io.github.mhuebert/inside-out {:local/root "../inside-out"}
         ;; Google Cloud
         com.google.firebase/firebase-admin {:mvn/version "6.13.0"}
 

--- a/src/org/sparkboard/client/views.cljs
+++ b/src/org/sparkboard/client/views.cljs
@@ -26,7 +26,7 @@
                  [rough/card {:class "pa3"}
                   [rough/link {:href (routes/path-for [:org/one org])}
                    (:org/title org)]]))
-          (ws/use-query! [:org/index]))]
+          (ws/use-query! [:org/index {}]))]
    [:section#add-org
     [(routes/use-view :org/create)]]])
 

--- a/src/org/sparkboard/client/views.cljs
+++ b/src/org/sparkboard/client/views.cljs
@@ -28,8 +28,20 @@
                    (:org/title org)]]))
           (ws/use-query! [:org/index]))]
    [:section#add-org
-    [rough/button {:on-click #(routes/mutation! [:org/create] {:foo "foo"})}
-     "create org"]]])
+    [(routes/use-view :org/create)]]])
+
+(v/defview org:create [params]
+  (let [org (use-state {:org/title ""})
+        [pending? start-transition] (react/useTransition)]
+    [:div
+     [:h2 (use-tr [:tr/org])]
+     [:form
+      [:label "Title"]
+      [rough/input {:type "text"
+                    :value (:org/title @org)
+                    :on-input (fn [event] (swap! org assoc :org/title (-> event .-target .-value)))}]
+      [rough/button {:on-click #(routes/mutation! [:org/create] @org)}
+       "create org"]]]))
 
 (v/defview org:one [{:as params :keys [org/id query-params]}]
   (let [value (ws/use-query! [:org/one {:org/id id}])
@@ -55,7 +67,7 @@
                                  routes/merge-query!
                                  set-query-params!))))
           :value q}]
-        (when pending? [:div [rough/spinner]])
+        (when pending? [:div [rough/spinner {:duration 300}]])
         (into [:ul]
               (map (comp (partial vector :li)
                          str))

--- a/src/org/sparkboard/client/views.cljs
+++ b/src/org/sparkboard/client/views.cljs
@@ -25,7 +25,8 @@
                  [rough/card {:class "pa3"}
                   [rough/link {:href (routes/path-for [:org/one org])}
                    (:org/title org)]
-                  [rough/icon-button {:on-click #(routes/mutate! {:route [:org/delete]} org)}
+                  [rough/icon-button {:on-click #(when (js/window.confirm (str "Really delete organization " (:org/title org) "?"))
+                                                   (routes/mutate! {:route [:org/delete]} org))}
                    "X"]]))
           (ws/use-query! [:org/index {}]))]
    [:section#add-org

--- a/src/org/sparkboard/client/views.cljs
+++ b/src/org/sparkboard/client/views.cljs
@@ -39,7 +39,16 @@
       [rough/input {:type "text"
                     :value (:org/title @org)
                     :on-input (fn [event] (swap! org assoc :org/title (-> event .-target .-value)))}]
-      [rough/button {:on-click #(routes/mutation! [:org/create] @org)}
+      [rough/button
+       {:on-click #(routes/mutate! {:route [:org/create]
+                                    :response-fn (fn [^js/Response res _url]
+                                                   (case (.-status res)
+                                                     200 (js/console.log "200 response")
+                                                     400 (js/console.warn "400 response" (.-body res))
+                                                     500 (js/console.error "500 response")
+                                                     (js/console.error "catch-all case"))
+                                                   res)}
+                                   @org)}
        "create org"]]]))
 
 (v/defview org:one [{:as params :keys [org/id query-params]}]
@@ -222,5 +231,5 @@
      [rough/input {:label "Board title"
                    :value n
                    :on-input #(n! (-> % .-target .-value))}]
-     [:div {:on-click #(routes/mutation! route {:board/title n})}
+     [:div {:on-click #(routes/mutate! {:route route} {:board/title n})}
       "Create a Board!"]]))

--- a/src/org/sparkboard/client/views.cljs
+++ b/src/org/sparkboard/client/views.cljs
@@ -9,8 +9,7 @@
    [org.sparkboard.routes :as routes]
    [org.sparkboard.views.rough :as rough]
    [org.sparkboard.websockets :as ws]
-   [tools.sparkboard.http :as sb.tools]
-   [yawn.hooks :refer [use-deref use-state]]
+   [yawn.hooks :refer [use-state]]
    [yawn.view :as v]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/org/sparkboard/client/views.cljs
+++ b/src/org/sparkboard/client/views.cljs
@@ -24,7 +24,9 @@
           (map (fn [org]
                  [rough/card {:class "pa3"}
                   [rough/link {:href (routes/path-for [:org/one org])}
-                   (:org/title org)]]))
+                   (:org/title org)]
+                  [rough/icon-button {:on-click #(routes/mutate! {:route [:org/delete]} org)}
+                   "X"]]))
           (ws/use-query! [:org/index {}]))]
    [:section#add-org
     [(routes/use-view :org/create)]]])

--- a/src/org/sparkboard/datalevin.clj
+++ b/src/org/sparkboard/datalevin.clj
@@ -107,3 +107,43 @@
  ;; TODO CIDER print handler for re-db entities
 
  )
+
+(comment ;;;; how to delete?
+  ;; DAL created a bunch of dummy orgs, to test front-end reactivity &
+  ;; mutations. Now they need to go away.
+
+  ;; See all orgs so I can pick out the ones to delete
+  (->> (d/where [:org/id])
+       (mapv (d/pull '[*])))
+
+  ;; Get entity for an org
+  (dl/q '[:find ?e .
+          :in $ ?org-id
+          :where [?e :org/id ?org-id]]
+        (dl/db conn)
+        "30073ee5-ce10-43c8-ae1f-145d84e7a3ee")
+
+  ;; Delete it
+  (let [org {:org/id "30073ee5-ce10-43c8-ae1f-145d84e7a3ee",
+             :org/title "dave4",
+             :ts/created-by {:db/id 130077}}
+        eid (dl/q '[:find ?e .
+                    :in $ ?org-id
+                    :where [?e :org/id ?org-id]]
+                  (dl/db conn)
+                  (:org/id org))]
+    (d/transact! [[:db.fn/retractEntity eid]]))
+
+  ;; FIXME fails if entity does not exist / has already been deleted
+  
+  )
+
+(defn org-entity [conn org-id]
+  (dl/q '[:find ?e .
+         :in $ ?org-id
+         :where [?e :org/id ?org-id]]
+       @conn org-id))
+
+;; FIXME this probably shouldn't exist here?
+(defn retract! [entity-id]
+  (d/transact! [[:db.fn/retractEntity entity-id]]))

--- a/src/org/sparkboard/firebase/admin_db_api.cljc
+++ b/src/org/sparkboard/firebase/admin_db_api.cljc
@@ -15,15 +15,15 @@
 #?(:cljs
    (defn firebase-fetch [method]
      (fn [path & [opts]]
-       (http/http-req (str database-url (str/replace-first path #"^/*" "/") ".json")
-                      (-> opts
-                          (assoc :method method)
-                          (update :query #(-> (if (map? %) % (apply hash-map %))
-                                              (assoc :auth (:firebase/database-secret env/config))
-                                              (u/update-some {:orderBy clj->json
-                                                              :startAt clj->json
-                                                              :endAt clj->json
-                                                              :equalTo clj->json}))))))))
+       (http/request (str database-url (str/replace-first path #"^/*" "/") ".json")
+                     (-> opts
+                         (assoc :method method)
+                         (update :query #(-> (if (map? %) % (apply hash-map %))
+                                             (assoc :auth (:firebase/database-secret env/config))
+                                             (u/update-some {:orderBy clj->json
+                                                             :startAt clj->json
+                                                             :endAt clj->json
+                                                             :equalTo clj->json}))))))))
 
 #?(:clj
    (defn- apply-query [ref query]

--- a/src/org/sparkboard/routes.cljc
+++ b/src/org/sparkboard/routes.cljc
@@ -164,8 +164,12 @@
           (string? path)
           (-> match-route :route)))
 
-(defn mutation! [route & args]
+(defn mutate! [{:keys [route response-fn] :as opts} & args]
   (sb.tools/http-req (path-for route)
-                     {:body (vec args)
-                      :body/content-type :transit+json
-                      :method "POST"}))
+                     (merge {:body (vec args)
+                             :body/content-type :transit+json
+                             :method "POST"}
+                            ;; `response-fn`, if provided, should be a fn of two
+                            ;; args [response url] and returning the response
+                            ;; after doing whatever it needs to do.
+                            (dissoc opts :body :route))))

--- a/src/org/sparkboard/routes.cljc
+++ b/src/org/sparkboard/routes.cljc
@@ -37,6 +37,9 @@
             :org/create {:route "/v2/o/create"
                          :view `views/org:create
                          :mutation `queries/org:create}
+            :org/delete {:route "/v2/o/delete"
+                         ;; :view `views/org:delete
+                         :mutation `queries/org:delete}
             :board/create {:route ["/v2/o/" :org/id "/create-board"]
                            :view `views/board:create
                            :mutation `queries/board:create}

--- a/src/org/sparkboard/routes.cljc
+++ b/src/org/sparkboard/routes.cljc
@@ -8,7 +8,7 @@
             [org.sparkboard.macros :refer [lazy-views]]
             [re-db.reactive :as r]
             [tools.sparkboard.util :as u]
-            [tools.sparkboard.http :as sb.tools]
+            [tools.sparkboard.http :as sb.http]
             #?(:cljs [tools.sparkboard.browser.query-params :as query-params])
             #?(:cljs [shadow.lazy :as lazy])
             #?(:cljs [vendor.pushy.core :as pushy])
@@ -168,11 +168,11 @@
           (-> match-route :route)))
 
 (defn mutate! [{:keys [route response-fn] :as opts} & args]
-  (sb.tools/http-req (path-for route)
-                     (merge {:body (vec args)
-                             :body/content-type :transit+json
-                             :method "POST"}
-                            ;; `response-fn`, if provided, should be a fn of two
-                            ;; args [response url] and returning the response
-                            ;; after doing whatever it needs to do.
-                            (dissoc opts :body :route))))
+  (sb.http/request (path-for route)
+                   (merge {:body (vec args)
+                           :body/content-type :transit+json
+                           :method "POST"}
+                          ;; `response-fn`, if provided, should be a fn of two
+                          ;; args [response url] and returning the response
+                          ;; after doing whatever it needs to do.
+                          (dissoc opts :body :route))))

--- a/src/org/sparkboard/server/queries.clj
+++ b/src/org/sparkboard/server/queries.clj
@@ -4,7 +4,8 @@
             [re-db.memo :as memo]
             [re-db.reactive :as r]
             [re-db.xform :as xf]
-            [re-db.read :as read]))
+            [re-db.read :as read]
+            [clojure.pprint :refer [pprint]]))
 
 (defmacro defquery
   "Defines a query function. The function will be memoized and return a {:value / :error} map."
@@ -18,6 +19,10 @@
 (defquery $org:index [_]
   (->> (db/where [:org/id])
        (mapv (re-db.api/pull '[*]))))
+
+(comment
+ (db/transact! [{:org/id (str (rand-int 10000))
+                 :org/title (str (rand-int 10000))}]))
 
 (defquery $org:one [{:keys [org/id]}]
   (db/pull '[:org/id
@@ -92,5 +97,15 @@
  (r/become !k (r/reaction 10))
 
 
+ (r/session
+  (let [!orgs (r/reaction
+                (prn :counting-orgs)
+                (count (db/where [:org/title])))]
+    (prn @!orgs)
+    (pprint (db/transact! [{:org/id (str (rand-int 10000))
+                            :org/title (str (rand-int 10000))}]))
+    (prn @!orgs)
+
+    ))
 
  )

--- a/src/org/sparkboard/server/queries.clj
+++ b/src/org/sparkboard/server/queries.clj
@@ -1,11 +1,11 @@
 (ns org.sparkboard.server.queries
-  (:require [org.sparkboard.datalevin :as sb.datalevin :refer [conn]]
+  (:require [clojure.pprint :refer [pprint]]
+            [org.sparkboard.datalevin :as sb.datalevin :refer [conn]]
             [re-db.api :as db]
             [re-db.memo :as memo]
             [re-db.reactive :as r]
-            [re-db.xform :as xf]
             [re-db.read :as read]
-            [clojure.pprint :refer [pprint]]))
+            [re-db.xform :as xf]))
 
 (defmacro defquery
   "Defines a query function. The function will be memoized and return a {:value / :error} map."
@@ -93,6 +93,15 @@
        (catch Exception e
          {:status 500
           :body {:error (.getMessage e)}})))
+
+(defn org:delete [context _params org]
+  ;; FIXME access control
+  (->> org
+       :org/id
+       (sb.datalevin/org-entity conn)
+       sb.datalevin/retract!)
+  (return {:org org
+           :deleted? true}))
 
 (comment
  (r/redef !k (r/reaction 100))

--- a/src/org/sparkboard/server/queries.clj
+++ b/src/org/sparkboard/server/queries.clj
@@ -67,12 +67,11 @@
 
 (defn return [body]
   {:status 200
-   ;; unsure if this necessary / what we should do
-   ;; w/ muuntaja
+   ;; FIXME unsure if this works / is necessary / what we should do w/muuntaja
    :headers {"content-type" "application/transit+json"}
    :body body})
 
-(defn org:create [context _ org]
+(defn org:create [context _params org]
   ;; open questions:
   ;; - return value of a mutation goes where? (eg. errors, messages...)
 

--- a/src/tools/sparkboard/http.cljc
+++ b/src/tools/sparkboard/http.cljc
@@ -58,7 +58,7 @@
             (dissoc :auth/token)))
     opts))
 
-(defn http-req [url {:as opts :keys [query body auth/token method response-fn]}]
+(defn request [url {:as opts :keys [query body auth/token method response-fn]}]
   (let [opts (cond-> opts
                      token (assoc-in [:headers "Authorization"] (str "Bearer: " token))
                      body (format-req-body)
@@ -81,7 +81,7 @@
   (fn [path & [opts]]
     (http-fn path (merge extra-opts opts))))
 
-(def get+ (partial-opts http-req {:method "GET"}))
-(def put+ (partial-opts http-req {:method "PUT"}))
-(def post+ (partial-opts http-req {:method "POST"}))
-(def patch+ (partial-opts http-req {:method "PATCH"}))
+(def get+ (partial-opts request {:method "GET"}))
+(def put+ (partial-opts request {:method "PUT"}))
+(def post+ (partial-opts request {:method "POST"}))
+(def patch+ (partial-opts request {:method "PATCH"}))

--- a/src/tools/sparkboard/http.cljc
+++ b/src/tools/sparkboard/http.cljc
@@ -64,7 +64,6 @@
                      body (format-req-body)
                      true (dissoc :query :auth/token :response-fn))
         url (cond-> url query (str "?" (uri/map->query-string query)))]
-    (println "http-req response-fn:" response-fn)
     (p/let [response #?(:cljs
                         (p/-> (fetch url (->js opts))
                               ((if response-fn


### PR DESCRIPTION
Some work on supporting routes like 
```clj 
:org/create {:route "/v2/o/create"
             :view `views/org:create
             :mutation `queries/org:create}
```

and using views like 

```clj 
[:section#add-org
  [(routes/use-view :org/create)]]
```

Re-evaluating queries is still not working completely, but at least reloading the browser gets the correct result.