### PR TITLE
Remove :entity/website for boards in one-time migration

### DIFF
--- a/src/sb/app/board/data.cljc
+++ b/src/sb/app/board/data.cljc
@@ -58,7 +58,6 @@
                                               (? :image/background)
                                               (? :image/sub-header)
 
-                                              (? :entity/website)
                                               (? :entity/meta-description)
                                               (? :entity/description)
                                               (? :entity/domain-name)

--- a/src/sb/app/entity/data.cljc
+++ b/src/sb/app/entity/data.cljc
@@ -63,8 +63,6 @@
                                  s-   [:map {:closed true} :video/url]}
      :entity/public?            {:doc "Contents of this entity can be accessed without authentication (eg. and indexed by search engines)"
                                  s-   :boolean}
-     :entity/website            {:doc "External website for entity"
-                                 s-   :http/url}
      :entity/social-feed        {s- :social/feed}
      :entity/uploads            (sch/ref :many)
      :entity/images             {s- [:map-of

--- a/src/sb/migrate/one_time.clj
+++ b/src/sb/migrate/one_time.clj
@@ -742,7 +742,7 @@
                "headerJs" (rename :board/custom-js)
                "projectTags" rm
                "registrationEmailBody" (rename :board/invite-email-text)
-               "learnMoreLink" (rename :entity/website)
+               "learnMoreLink" rm ;; all three uses are dead URLs
                "metaDesc" (rename :entity/meta-description)
                "registrationMessage" (& (xf prose)
                                         (rename :board/registration-page-message))


### PR DESCRIPTION
All three uses are dead URLs